### PR TITLE
feat: retrieve package description and incorporate into `swiftpkg.PackageInfo`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -104,6 +104,8 @@ filegroup(
         "//gazelle:all_files",
         "//gazelle/internal/jsonutils:all_files",
         "//gazelle/internal/pathdistance:all_files",
+        "//gazelle/internal/spdesc:all_files",
+        "//gazelle/internal/spdump:all_files",
         "//gazelle/internal/stringslices:all_files",
         "//gazelle/internal/swift:all_files",
         "//gazelle/internal/swiftbin:all_files",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -97,8 +97,11 @@ filegroup(
     name = "local_repository_files",
     # Include every package that is required by the child workspaces.
     srcs = [
+        ".bazelrc",
         "BUILD.bazel",
         "WORKSPACE",
+        "ci.bazelrc",
+        "shared.bazelrc",
         ":deps.bzl",
         ":go_deps.bzl",
         "//gazelle:all_files",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,12 +46,13 @@ bazel_skylib_workspace()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Point to the https://github.com/bazel-contrib/rules_bazel_integration_test/tree/add_remove_bazel_symlinks_new branch.
 http_archive(
     name = "contrib_rules_bazel_integration_test",
-    sha256 = "e26a1cd5799785a822206f7d017b6771f446e6f2c5e0cb5eb02183ff7e2bccc0",
-    strip_prefix = "rules_bazel_integration_test-c4f5f6ff82b14de35beb53b36e535ff887384945",
+    sha256 = "985fa668fc555687c8e7e08ae209f228a8723a4fc6e51122025a17f413e9278a",
+    strip_prefix = "rules_bazel_integration_test-d94af0ffe3fdaab01c26a5e46816f9c217e5e20d",
     urls = [
-        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/c4f5f6ff82b14de35beb53b36e535ff887384945.tar.gz",
+        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/d94af0ffe3fdaab01c26a5e46816f9c217e5e20d.tar.gz",
     ],
 )
 

--- a/examples/simple/.bazelrc
+++ b/examples/simple/.bazelrc
@@ -1,0 +1,8 @@
+# Import Shared settings
+import %workspace%/../../shared.bazelrc
+
+# Import CI settings.
+import %workspace%/../../ci.bazelrc
+
+# Try to import a local.rc file; typically, written by CI
+try-import %workspace%/../../local.bazelrc

--- a/gazelle/internal/spdesc/BUILD.bazel
+++ b/gazelle/internal/spdesc/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "spdesc",
+    srcs = ["manifest.go"],
+    importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/spdesc",
+    visibility = ["//gazelle:__subpackages__"],
+)
+
+go_test(
+    name = "spdesc_test",
+    srcs = ["manifest_test.go"],
+    deps = [
+        ":spdesc",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/gazelle/internal/spdesc/BUILD.bazel
+++ b/gazelle/internal/spdesc/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 # MARK: - Integration Test
@@ -25,3 +26,5 @@ go_test(
         "@com_github_stretchr_testify//assert",
     ],
 )
+
+bzlformat_pkg(name = "bzlformat")

--- a/gazelle/internal/spdesc/BUILD.bazel
+++ b/gazelle/internal/spdesc/BUILD.bazel
@@ -1,5 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# MARK: - Integration Test
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["*"]),
+    visibility = ["//:__subpackages__"],
+)
+
+# MARK: - Golang
+
 go_library(
     name = "spdesc",
     srcs = ["manifest.go"],

--- a/gazelle/internal/spdesc/manifest.go
+++ b/gazelle/internal/spdesc/manifest.go
@@ -13,11 +13,26 @@ func NewManifestFromJSON(bytes []byte) (*Manifest, error) {
 	return &manifest, nil
 }
 
+// Manifest
+
 type Manifest struct {
 	Name                string
 	ManifestDisplayName string `json:"manifest_display_name"`
 	Path                string
+	ToolsVersion        string `json:"tools_version"`
 	// Platforms          []Platform
 	// Products           []Product
 	// Targets            []Target
 }
+
+// Targets
+
+// type Target struct {
+// 	C99name            string
+// 	ModuleType         string
+// 	Name               string
+// 	Path               string
+// 	Sources            []string
+// 	TargetDependencies []string
+// 	Type               string
+// }

--- a/gazelle/internal/spdesc/manifest.go
+++ b/gazelle/internal/spdesc/manifest.go
@@ -20,19 +20,21 @@ type Manifest struct {
 	ManifestDisplayName string `json:"manifest_display_name"`
 	Path                string
 	ToolsVersion        string `json:"tools_version"`
+	Targets             []Target
 	// Platforms          []Platform
 	// Products           []Product
-	// Targets            []Target
 }
 
 // Targets
 
-// type Target struct {
-// 	C99name            string
-// 	ModuleType         string
-// 	Name               string
-// 	Path               string
-// 	Sources            []string
-// 	TargetDependencies []string
-// 	Type               string
-// }
+type Target struct {
+	Name                string
+	C99name             string `json:"c99name"`
+	Type                string
+	ModuleType          string `json:"module_type"`
+	Path                string
+	Sources             []string
+	TargetDependencies  []string `json:"target_dependencies"`
+	ProductDependencies []string `json:"product_dependencies"`
+	ProductMemberships  []string `json:"product_memberships"`
+}

--- a/gazelle/internal/spdesc/manifest.go
+++ b/gazelle/internal/spdesc/manifest.go
@@ -22,7 +22,7 @@ type Manifest struct {
 	ToolsVersion        string `json:"tools_version"`
 	Targets             []Target
 	Platforms           []Platform
-	// Products           []Product
+	Products            []Product
 	// Dependencies       []Dependency
 }
 
@@ -45,6 +45,39 @@ type Target struct {
 type Platform struct {
 	Name    string
 	Version string
+}
+
+// Product
+
+type ProductType int
+
+const (
+	UnknownProductType ProductType = iota
+	ExecutableProductType
+	LibraryProductType
+	PluginProductType
+)
+
+func (pt *ProductType) UnmarshalJSON(b []byte) error {
+	var anyMap map[string]any
+	err := json.Unmarshal(b, &anyMap)
+	if err != nil {
+		return err
+	}
+	if _, ok := anyMap["executable"]; ok {
+		*pt = ExecutableProductType
+	} else if _, ok = anyMap["library"]; ok {
+		*pt = LibraryProductType
+	} else if _, ok = anyMap["plugin"]; ok {
+		*pt = PluginProductType
+	}
+	return nil
+}
+
+type Product struct {
+	Name    string
+	Targets []string
+	Type    ProductType
 }
 
 // Dependency

--- a/gazelle/internal/spdesc/manifest.go
+++ b/gazelle/internal/spdesc/manifest.go
@@ -21,8 +21,9 @@ type Manifest struct {
 	Path                string
 	ToolsVersion        string `json:"tools_version"`
 	Targets             []Target
-	// Platforms          []Platform
+	Platforms           []Platform
 	// Products           []Product
+	// Dependencies       []Dependency
 }
 
 // Targets
@@ -38,3 +39,19 @@ type Target struct {
 	ProductDependencies []string `json:"product_dependencies"`
 	ProductMemberships  []string `json:"product_memberships"`
 }
+
+// Platforms
+
+type Platform struct {
+	Name    string
+	Version string
+}
+
+// Dependency
+
+//type Dependency struct {
+//	Identity string
+//	Type     string
+//	URL      string
+//	//Requirements []Requirement
+//}

--- a/gazelle/internal/spdesc/manifest.go
+++ b/gazelle/internal/spdesc/manifest.go
@@ -23,7 +23,7 @@ type Manifest struct {
 	Targets             []Target
 	Platforms           []Platform
 	Products            []Product
-	// Dependencies       []Dependency
+	Dependencies        []Dependency
 }
 
 // Targets
@@ -82,9 +82,20 @@ type Product struct {
 
 // Dependency
 
-//type Dependency struct {
-//	Identity string
-//	Type     string
-//	URL      string
-//	//Requirements []Requirement
-//}
+type Dependency struct {
+	Identity     string
+	Type         string
+	URL          string
+	Requirement DependencyRequirement
+}
+
+// Requirement
+
+type DependencyRequirement struct {
+	Range []VersionRange
+}
+
+type VersionRange struct {
+	LowerBound string `json:"lower_bound"`
+	UpperBound string `json:"upper_bound"`
+}

--- a/gazelle/internal/spdesc/manifest.go
+++ b/gazelle/internal/spdesc/manifest.go
@@ -1,0 +1,23 @@
+package spdesc
+
+import "encoding/json"
+
+// The JSON formats described in this file are for the `swift package describe --type json` JSON output.
+
+func NewManifestFromJSON(bytes []byte) (*Manifest, error) {
+	var manifest Manifest
+	err := json.Unmarshal(bytes, &manifest)
+	if err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+type Manifest struct {
+	Name                string
+	ManifestDisplayName string `json:"manifest_display_name"`
+	Path                string
+	// Platforms          []Platform
+	// Products           []Product
+	// Targets            []Target
+}

--- a/gazelle/internal/spdesc/manifest_test.go
+++ b/gazelle/internal/spdesc/manifest_test.go
@@ -16,6 +16,13 @@ func TestNewManifestFromJSON(t *testing.T) {
 		Platforms: []spdesc.Platform{
 			{Name: "macos", Version: "10.15"},
 		},
+		Products: []spdesc.Product{
+			{
+				Name:    "printstuff",
+				Targets: []string{"MySwiftPackage"},
+				Type:    spdesc.ExecutableProductType,
+			},
+		},
 		Targets: []spdesc.Target{
 			{
 				Name:       "MySwiftPackageTests",

--- a/gazelle/internal/spdesc/manifest_test.go
+++ b/gazelle/internal/spdesc/manifest_test.go
@@ -1,0 +1,135 @@
+package spdesc_test
+
+import (
+	"testing"
+
+	"github.com/cgrindel/swift_bazel/gazelle/internal/spdesc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewManifestFromJSON(t *testing.T) {
+	expected := &spdesc.Manifest{
+		Name:                "MySwiftPackage",
+		ManifestDisplayName: "MySwiftPackage",
+		Path:                "/Users/chuck/code/cgrindel/swift_bazel/gh008_incorporate_describe/examples/MySwiftPackage",
+		// Dependencies: []spdesc.Dependency{
+		// 	{
+		// 		Name: "swift-argument-parser",
+		// 		URL:  "https://github.com/apple/swift-argument-parser",
+		// 		Requirement: spdesc.DependencyRequirement{
+		// 			Range: []spdesc.VersionRange{
+		// 				{LowerBound: "1.2.0", UpperBound: "2.0.0"},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// Platforms: []spdesc.Platform{
+		// 	{Name: "macos", Version: "10.15"},
+		// },
+		// Products: []spdesc.Product{
+		// 	{
+		// 		Name:    "printstuff",
+		// 		Targets: []string{"MySwiftPackage"},
+		// 		Type:    spdesc.ExecutableProductType,
+		// 	},
+		// },
+		// Targets: []spdesc.Target{
+		// 	{
+		// 		Name: "MySwiftPackage",
+		// 		Type: spdesc.ExecutableTargetType,
+		// 		Dependencies: []spdesc.TargetDependency{
+		// 			{
+		// 				Product: &spdesc.ProductReference{
+		// 					ProductName:    "ArgumentParser",
+		// 					DependencyName: "swift-argument-parser",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	{
+		// 		Name: "MySwiftPackageTests",
+		// 		Type: spdesc.TestTargetType,
+		// 		Dependencies: []spdesc.TargetDependency{
+		// 			{
+		// 				ByName: &spdesc.ByNameReference{TargetName: "MySwiftPackage"},
+		// 			},
+		// 		},
+		// 	},
+		// },
+	}
+	manifest, err := spdesc.NewManifestFromJSON([]byte(swiftPackageJSONStr))
+	assert.NoError(t, err)
+	assert.Equal(t, expected, manifest)
+}
+
+const swiftPackageJSONStr = `
+{
+  "dependencies" : [
+    {
+      "identity" : "swift-argument-parser",
+      "requirement" : {
+        "range" : [
+          {
+            "lower_bound" : "1.2.0",
+            "upper_bound" : "2.0.0"
+          }
+        ]
+      },
+      "type" : "sourceControl",
+      "url" : "https://github.com/apple/swift-argument-parser"
+    }
+  ],
+  "manifest_display_name" : "MySwiftPackage",
+  "name" : "MySwiftPackage",
+  "path" : "/Users/chuck/code/cgrindel/swift_bazel/gh008_incorporate_describe/examples/MySwiftPackage",
+  "platforms" : [
+    {
+      "name" : "macos",
+      "version" : "10.15"
+    }
+  ],
+  "products" : [
+    {
+      "name" : "printstuff",
+      "targets" : [
+        "MySwiftPackage"
+      ],
+      "type" : {
+        "executable" : null
+      }
+    }
+  ],
+  "targets" : [
+    {
+      "c99name" : "MySwiftPackageTests",
+      "module_type" : "SwiftTarget",
+      "name" : "MySwiftPackageTests",
+      "path" : "Tests/MySwiftPackageTests",
+      "sources" : [
+        "MySwiftPackageTests.swift"
+      ],
+      "target_dependencies" : [
+        "MySwiftPackage"
+      ],
+      "type" : "test"
+    },
+    {
+      "c99name" : "MySwiftPackage",
+      "module_type" : "SwiftTarget",
+      "name" : "MySwiftPackage",
+      "path" : "Sources/MySwiftPackage",
+      "product_dependencies" : [
+        "ArgumentParser"
+      ],
+      "product_memberships" : [
+        "printstuff"
+      ],
+      "sources" : [
+        "MySwiftPackage.swift"
+      ],
+      "type" : "executable"
+    }
+  ],
+  "tools_version" : "5.7"
+}
+`

--- a/gazelle/internal/spdesc/manifest_test.go
+++ b/gazelle/internal/spdesc/manifest_test.go
@@ -66,50 +66,6 @@ func TestNewManifestFromJSON(t *testing.T) {
 				},
 			},
 		},
-		// Dependencies: []spdesc.Dependency{
-		// 	{
-		// 		Name: "swift-argument-parser",
-		// 		URL:  "https://github.com/apple/swift-argument-parser",
-		// 		Requirement: spdesc.DependencyRequirement{
-		// 			Range: []spdesc.VersionRange{
-		// 				{LowerBound: "1.2.0", UpperBound: "2.0.0"},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// Platforms: []spdesc.Platform{
-		// 	{Name: "macos", Version: "10.15"},
-		// },
-		// Products: []spdesc.Product{
-		// 	{
-		// 		Name:    "printstuff",
-		// 		Targets: []string{"MySwiftPackage"},
-		// 		Type:    spdesc.ExecutableProductType,
-		// 	},
-		// },
-		// Targets: []spdesc.Target{
-		// 	{
-		// 		Name: "MySwiftPackage",
-		// 		Type: spdesc.ExecutableTargetType,
-		// 		Dependencies: []spdesc.TargetDependency{
-		// 			{
-		// 				Product: &spdesc.ProductReference{
-		// 					ProductName:    "ArgumentParser",
-		// 					DependencyName: "swift-argument-parser",
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	{
-		// 		Name: "MySwiftPackageTests",
-		// 		Type: spdesc.TestTargetType,
-		// 		Dependencies: []spdesc.TargetDependency{
-		// 			{
-		// 				ByName: &spdesc.ByNameReference{TargetName: "MySwiftPackage"},
-		// 			},
-		// 		},
-		// 	},
-		// },
 	}
 	manifest, err := spdesc.NewManifestFromJSON([]byte(swiftPackageJSONStr))
 	assert.NoError(t, err)

--- a/gazelle/internal/spdesc/manifest_test.go
+++ b/gazelle/internal/spdesc/manifest_test.go
@@ -12,6 +12,7 @@ func TestNewManifestFromJSON(t *testing.T) {
 		Name:                "MySwiftPackage",
 		ManifestDisplayName: "MySwiftPackage",
 		Path:                "/Users/chuck/code/cgrindel/swift_bazel/gh008_incorporate_describe/examples/MySwiftPackage",
+		ToolsVersion:        "5.7",
 		// Dependencies: []spdesc.Dependency{
 		// 	{
 		// 		Name: "swift-argument-parser",

--- a/gazelle/internal/spdesc/manifest_test.go
+++ b/gazelle/internal/spdesc/manifest_test.go
@@ -13,6 +13,37 @@ func TestNewManifestFromJSON(t *testing.T) {
 		ManifestDisplayName: "MySwiftPackage",
 		Path:                "/Users/chuck/code/cgrindel/swift_bazel/gh008_incorporate_describe/examples/MySwiftPackage",
 		ToolsVersion:        "5.7",
+		Targets: []spdesc.Target{
+			{
+				Name:       "MySwiftPackageTests",
+				C99name:    "MySwiftPackageTests",
+				ModuleType: "SwiftTarget",
+				Path:       "Tests/MySwiftPackageTests",
+				Sources: []string{
+					"MySwiftPackageTests.swift",
+				},
+				TargetDependencies: []string{
+					"MySwiftPackage",
+				},
+				Type: "test",
+			},
+			{
+				Name:       "MySwiftPackage",
+				C99name:    "MySwiftPackage",
+				Type:       "executable",
+				ModuleType: "SwiftTarget",
+				Path:       "Sources/MySwiftPackage",
+				Sources: []string{
+					"MySwiftPackage.swift",
+				},
+				ProductDependencies: []string{
+					"ArgumentParser",
+				},
+				ProductMemberships: []string{
+					"printstuff",
+				},
+			},
+		},
 		// Dependencies: []spdesc.Dependency{
 		// 	{
 		// 		Name: "swift-argument-parser",

--- a/gazelle/internal/spdesc/manifest_test.go
+++ b/gazelle/internal/spdesc/manifest_test.go
@@ -13,6 +13,9 @@ func TestNewManifestFromJSON(t *testing.T) {
 		ManifestDisplayName: "MySwiftPackage",
 		Path:                "/Users/chuck/code/cgrindel/swift_bazel/gh008_incorporate_describe/examples/MySwiftPackage",
 		ToolsVersion:        "5.7",
+		Platforms: []spdesc.Platform{
+			{Name: "macos", Version: "10.15"},
+		},
 		Targets: []spdesc.Target{
 			{
 				Name:       "MySwiftPackageTests",

--- a/gazelle/internal/spdesc/manifest_test.go
+++ b/gazelle/internal/spdesc/manifest_test.go
@@ -13,6 +13,18 @@ func TestNewManifestFromJSON(t *testing.T) {
 		ManifestDisplayName: "MySwiftPackage",
 		Path:                "/Users/chuck/code/cgrindel/swift_bazel/gh008_incorporate_describe/examples/MySwiftPackage",
 		ToolsVersion:        "5.7",
+		Dependencies: []spdesc.Dependency{
+			{
+				Identity: "swift-argument-parser",
+				Type:     "sourceControl",
+				URL:      "https://github.com/apple/swift-argument-parser",
+				Requirement: spdesc.DependencyRequirement{
+					Range: []spdesc.VersionRange{
+						{LowerBound: "1.2.0", UpperBound: "2.0.0"},
+					},
+				},
+			},
+		},
 		Platforms: []spdesc.Platform{
 			{Name: "macos", Version: "10.15"},
 		},

--- a/gazelle/internal/spdump/BUILD.bazel
+++ b/gazelle/internal/spdump/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "spdump",
+    srcs = ["manifest.go"],
+    importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/spdump",
+    visibility = ["//gazelle:__subpackages__"],
+    deps = [
+        "//gazelle/internal/jsonutils",
+        "@com_github_hashicorp_go_multierror//:go-multierror",
+    ],
+)
+
+go_test(
+    name = "spdump_test",
+    srcs = ["manifest_test.go"],
+    deps = [
+        ":spdump",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/gazelle/internal/spdump/BUILD.bazel
+++ b/gazelle/internal/spdump/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 # MARK: - Integration Test
@@ -29,3 +30,5 @@ go_test(
         "@com_github_stretchr_testify//assert",
     ],
 )
+
+bzlformat_pkg(name = "bzlformat")

--- a/gazelle/internal/spdump/BUILD.bazel
+++ b/gazelle/internal/spdump/BUILD.bazel
@@ -1,5 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# MARK: - Integration Test
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["*"]),
+    visibility = ["//:__subpackages__"],
+)
+
+# MARK: - Golang
+
 go_library(
     name = "spdump",
     srcs = ["manifest.go"],

--- a/gazelle/internal/spdump/manifest.go
+++ b/gazelle/internal/spdump/manifest.go
@@ -112,38 +112,26 @@ const (
 	PluginProductType
 )
 
+func (pt *ProductType) UnmarshalJSON(b []byte) error {
+	var anyMap map[string]any
+	err := json.Unmarshal(b, &anyMap)
+	if err != nil {
+		return err
+	}
+	if _, ok := anyMap["executable"]; ok {
+		*pt = ExecutableProductType
+	} else if _, ok = anyMap["library"]; ok {
+		*pt = LibraryProductType
+	} else if _, ok = anyMap["plugin"]; ok {
+		*pt = PluginProductType
+	}
+	return nil
+}
+
 type Product struct {
 	Name    string
 	Targets []string
 	Type    ProductType
-}
-
-func (p *Product) UnmarshalJSON(b []byte) error {
-	var errs error
-
-	var raw map[string]any
-	err := json.Unmarshal(b, &raw)
-	if err != nil {
-		return err
-	}
-	if p.Name, err = jsonutils.StringAtKey(raw, "name"); err != nil {
-		errs = multierror.Append(errs, err)
-	}
-	if p.Targets, err = jsonutils.StringsAtKey(raw, "targets"); err != nil {
-		errs = multierror.Append(errs, err)
-	}
-	if typeMap, err := jsonutils.MapAtKey(raw, "type"); err == nil {
-		if _, present := typeMap["executable"]; present {
-			p.Type = ExecutableProductType
-		} else if _, present = typeMap["library"]; present {
-			p.Type = LibraryProductType
-		} else if _, present = typeMap["plugin"]; present {
-			p.Type = PluginProductType
-		}
-	} else {
-		errs = multierror.Append(errs, err)
-	}
-	return errs
 }
 
 // Target

--- a/gazelle/internal/spdump/manifest.go
+++ b/gazelle/internal/spdump/manifest.go
@@ -1,4 +1,4 @@
-package swiftpkg
+package spdump
 
 import (
 	"encoding/json"

--- a/gazelle/internal/spdump/manifest_test.go
+++ b/gazelle/internal/spdump/manifest_test.go
@@ -1,43 +1,43 @@
-package swiftpkg_test
+package spdump_test
 
 import (
 	"testing"
 
-	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewManifestFromJSON(t *testing.T) {
-	expected := &swiftpkg.Manifest{
+	expected := &spdump.Manifest{
 		Name: "MySwiftPackage",
-		Dependencies: []swiftpkg.Dependency{
+		Dependencies: []spdump.Dependency{
 			{
 				Name: "swift-argument-parser",
 				URL:  "https://github.com/apple/swift-argument-parser",
-				Requirement: swiftpkg.DependencyRequirement{
-					Range: []swiftpkg.VersionRange{
+				Requirement: spdump.DependencyRequirement{
+					Range: []spdump.VersionRange{
 						{LowerBound: "1.2.0", UpperBound: "2.0.0"},
 					},
 				},
 			},
 		},
-		Platforms: []swiftpkg.Platform{
+		Platforms: []spdump.Platform{
 			{Name: "macos", Version: "10.15"},
 		},
-		Products: []swiftpkg.Product{
+		Products: []spdump.Product{
 			{
 				Name:    "printstuff",
 				Targets: []string{"MySwiftPackage"},
-				Type:    swiftpkg.ExecutableProductType,
+				Type:    spdump.ExecutableProductType,
 			},
 		},
-		Targets: []swiftpkg.Target{
+		Targets: []spdump.Target{
 			{
 				Name: "MySwiftPackage",
-				Type: swiftpkg.ExecutableTargetType,
-				Dependencies: []swiftpkg.TargetDependency{
+				Type: spdump.ExecutableTargetType,
+				Dependencies: []spdump.TargetDependency{
 					{
-						Product: &swiftpkg.ProductReference{
+						Product: &spdump.ProductReference{
 							ProductName:    "ArgumentParser",
 							DependencyName: "swift-argument-parser",
 						},
@@ -46,16 +46,16 @@ func TestNewManifestFromJSON(t *testing.T) {
 			},
 			{
 				Name: "MySwiftPackageTests",
-				Type: swiftpkg.TestTargetType,
-				Dependencies: []swiftpkg.TargetDependency{
+				Type: spdump.TestTargetType,
+				Dependencies: []spdump.TargetDependency{
 					{
-						ByName: &swiftpkg.ByNameReference{TargetName: "MySwiftPackage"},
+						ByName: &spdump.ByNameReference{TargetName: "MySwiftPackage"},
 					},
 				},
 			},
 		},
 	}
-	manifest, err := swiftpkg.NewManifestFromJSON([]byte(swiftPackageJSONStr))
+	manifest, err := spdump.NewManifestFromJSON([]byte(swiftPackageJSONStr))
 	assert.NoError(t, err)
 	assert.Equal(t, expected, manifest)
 }

--- a/gazelle/internal/swiftpkg/BUILD.bazel
+++ b/gazelle/internal/swiftpkg/BUILD.bazel
@@ -3,25 +3,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "swiftpkg",
-    srcs = [
-        "manifest.go",
-        "package_info.go",
-    ],
+    srcs = ["package_info.go"],
     importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg",
     visibility = ["//gazelle:__subpackages__"],
     deps = [
-        "//gazelle/internal/jsonutils",
+        "//gazelle/internal/spdump",
         "//gazelle/internal/swiftbin",
-        "@com_github_hashicorp_go_multierror//:go-multierror",
     ],
 )
 
 go_test(
     name = "swiftpkg_test",
-    srcs = [
-        "manifest_test.go",
-        "package_info_test.go",
-    ],
+    srcs = ["package_info_test.go"],
     # The PackageInfo tests use SwiftBin to create an actual Swift package. To use Swift, the test
     # needs to be executed outside of the sandbox.
     local = True,

--- a/gazelle/internal/swiftpkg/BUILD.bazel
+++ b/gazelle/internal/swiftpkg/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg",
     visibility = ["//gazelle:__subpackages__"],
     deps = [
+        "//gazelle/internal/spdesc",
         "//gazelle/internal/spdump",
         "//gazelle/internal/swiftbin",
     ],

--- a/gazelle/internal/swiftpkg/package_info.go
+++ b/gazelle/internal/swiftpkg/package_info.go
@@ -1,6 +1,7 @@
 package swiftpkg
 
 import (
+	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftbin"
 )
 
@@ -8,8 +9,8 @@ type PackageInfo struct {
 	// Package directory
 	Dir string
 
-	// The manifest information 
-	Manifest *Manifest
+	// The manifest information
+	Manifest *spdump.Manifest
 }
 
 func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
@@ -17,13 +18,13 @@ func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	manifest, err := NewManifestFromJSON(dump)
+	manifest, err := spdump.NewManifestFromJSON(dump)
 	if err != nil {
 		return nil, err
 	}
 
 	return &PackageInfo{
-		Dir: dir,
+		Dir:      dir,
 		Manifest: manifest,
 	}, nil
 }

--- a/gazelle/internal/swiftpkg/package_info.go
+++ b/gazelle/internal/swiftpkg/package_info.go
@@ -1,6 +1,7 @@
 package swiftpkg
 
 import (
+	"github.com/cgrindel/swift_bazel/gazelle/internal/spdesc"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftbin"
 )
@@ -9,8 +10,11 @@ type PackageInfo struct {
 	// Package directory
 	Dir string
 
-	// The manifest information
-	Manifest *spdump.Manifest
+	// Info from the dump
+	DumpManifest *spdump.Manifest
+
+	// Info from the describe
+	DescManifest *spdesc.Manifest
 }
 
 func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
@@ -18,13 +22,23 @@ func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	manifest, err := spdump.NewManifestFromJSON(dump)
+	dumpManifest, err := spdump.NewManifestFromJSON(dump)
+	if err != nil {
+		return nil, err
+	}
+
+	desc, err := sw.DescribePackage(dir)
+	if err != nil {
+		return nil, err
+	}
+	descManifest, err := spdesc.NewManifestFromJSON(desc)
 	if err != nil {
 		return nil, err
 	}
 
 	return &PackageInfo{
-		Dir:      dir,
-		Manifest: manifest,
+		Dir:          dir,
+		DumpManifest: dumpManifest,
+		DescManifest: descManifest,
 	}, nil
 }

--- a/gazelle/internal/swiftpkg/package_info_test.go
+++ b/gazelle/internal/swiftpkg/package_info_test.go
@@ -29,6 +29,7 @@ func TestPackageInfo(t *testing.T) {
 		pi, err := swiftpkg.NewPackageInfo(sb, dir)
 		assert.NoError(t, err)
 		assert.Equal(t, dir, pi.Dir)
-		assert.Equal(t, pkgName, pi.Manifest.Name)
+		assert.Equal(t, pkgName, pi.DumpManifest.Name)
+		assert.Equal(t, pkgName, pi.DescManifest.Name)
 	})
 }

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 go.starlark.net v0.0.0-20210223155950-e043a3d3c984/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20221110155412-d0897a79cd37 h1:wKMvZzBFHbOCGvF2OmxR5Fqv/jDlkt7slnPz5ejEU8A=
-golang.org/x/exp v0.0.0-20221110155412-d0897a79cd37/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/exp v0.0.0-20221114191408-850992195362 h1:NoHlPRbyl1VFI6FjwHtPQCN7wAMXI6cKcqrmXhOOfBQ=
 golang.org/x/exp v0.0.0-20221114191408-850992195362/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -264,8 +264,8 @@ def swift_bazel_go_dependencies():
         name = "org_golang_x_exp",
         build_external = "external",
         importpath = "golang.org/x/exp",
-        sum = "h1:wKMvZzBFHbOCGvF2OmxR5Fqv/jDlkt7slnPz5ejEU8A=",
-        version = "v0.0.0-20221110155412-d0897a79cd37",
+        sum = "h1:NoHlPRbyl1VFI6FjwHtPQCN7wAMXI6cKcqrmXhOOfBQ=",
+        version = "v0.0.0-20221114191408-850992195362",
     )
     go_repository(
         name = "org_golang_x_lint",


### PR DESCRIPTION
- Moved dump manifest models to `spdump`.
- Implemented `spdesc` with the describe models
- Add describe models to `swiftpkg.PackageInfo`.

Related to #8 