### PR TITLE
chore: upgrade `bazel-starlib` and use `bzltidy`

### DIFF
--- a/.github/actions/build_and_test/action.yml
+++ b/.github/actions/build_and_test/action.yml
@@ -4,15 +4,15 @@ description: Common build and test steps.
 runs:
   using: composite
   steps:
+    - name: Ensure everything is tidy
+      shell: bash
+      run: |
+        bazelisk run //:tidy_check
+
     - name: Execute Tests
       shell: bash
       run: |
         bazelisk test //... 
-
-    - name: Ensure Bazel packages covered by bzlformat_pkg
-      shell: bash
-      run: |
-        bazelisk run //:bzlformat_missing_pkgs_test
 
     - name: Execute Integration Tests
       shell: bash

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_missing_pkgs", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
 load("@cgrindel_bazel_starlib//shlib/rules:execute_binary.bzl", "execute_binary")
 load("@cgrindel_bazel_starlib//updatesrc:defs.bzl", "updatesrc_update_all")
 load(
@@ -18,20 +19,21 @@ bzlformat_missing_pkgs(
 
 # MARK: - Tidy / Update Source Files
 
-updatesrc_update_all(
+updatesrc_update_all(name = "update_all")
+
+tidy(
     name = "tidy",
-    targets_to_run = [
-        # Run go_mod_tidy before gazelle_update_repos
-        ":go_mod_tidy",
-        ":gazelle_update_repos",
-        ":gazelle",
-    ],
-    targets_to_run_before = [
+    targets = [
         # Remove the child workspace symlinks before doing some of the other
         # operations that my experience infinite symlink expansion errors.
         "@contrib_rules_bazel_integration_test//tools:remove_child_wksp_bazel_symlinks",
         "@contrib_rules_bazel_integration_test//tools:update_deleted_packages",
         ":bzlformat_missing_pkgs_fix",
+        ":update_all",
+        # Run go_mod_tidy before gazelle_update_repos
+        ":go_mod_tidy",
+        ":gazelle_update_repos",
+        ":gazelle",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,10 +49,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Point to the https://github.com/bazel-contrib/rules_bazel_integration_test/tree/add_remove_bazel_symlinks_new branch.
 http_archive(
     name = "contrib_rules_bazel_integration_test",
-    sha256 = "985fa668fc555687c8e7e08ae209f228a8723a4fc6e51122025a17f413e9278a",
-    strip_prefix = "rules_bazel_integration_test-d94af0ffe3fdaab01c26a5e46816f9c217e5e20d",
+    sha256 = "ef93cb1f609819294649a30b545382e269bf7d71a2f9730e5189de22e12d788e",
+    strip_prefix = "rules_bazel_integration_test-5426ab1778a24149ec25b3ba84f57200ce090458",
     urls = [
-        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/d94af0ffe3fdaab01c26a5e46816f9c217e5e20d.tar.gz",
+        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/5426ab1778a24149ec25b3ba84f57200ce090458.tar.gz",
     ],
 )
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -44,9 +44,9 @@ def swift_bazel_dependencies():
     maybe(
         http_archive,
         name = "cgrindel_bazel_starlib",
-        sha256 = "f10f9a47f23a76e6cc6f8af0b2d0c6377452e5b17ebeed6dbd656f0ba2aaa4ec",
-        strip_prefix = "bazel-starlib-0.8.1",
+        sha256 = "42a496dddbc089c68cd72b1f20dfe6acf474c53043dafe230ec887f617c0c252",
+        strip_prefix = "bazel-starlib-0.9.0",
         urls = [
-            "http://github.com/cgrindel/bazel-starlib/archive/v0.8.1.tar.gz",
+            "http://github.com/cgrindel/bazel-starlib/archive/v0.9.0.tar.gz",
         ],
     )


### PR DESCRIPTION
- Upgrade `bazel-starlib` to 0.9.0.
- Use `tidy` from `bzltidy`.

Closes #26.