### PR TITLE
chore: use `gha_join_jobs` for `all_ci_tests`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,8 @@ jobs:
   all_ci_tests:
     runs-on: ubuntu-20.04
     needs: [macos_build, ubuntu_build]
+    if: ${{ always() }}
     steps:
-      - name: All is Well
-        shell: bash
-        run: |
-          echo "All is well!"
-
+      - uses: cgrindel/gha_join_jobs@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ensure that job status from dependent jobs propagates.