### PR TITLE
feat: parse resolve package JSON and return pins

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -65,6 +65,8 @@ bazel_integration_tests(
 
 # MARK: - Test Suites
 
+# GH009: Add pkg_manifest_test to test_suite declarations
+
 test_suite(
     name = "smoke_integration_tests",
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,

--- a/examples/pkg_manifest/BUILD.bazel
+++ b/examples/pkg_manifest/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 # MARK: - Gazelle
 
@@ -10,9 +11,11 @@ gazelle_binary(
     ],
 )
 
-# gazelle:prefix github.com/cgrindel/swift_bazel/examples/simple
 gazelle(
     name = "gazelle",
+    extra_args = [
+        "-gen_from_pkg_manifest",
+    ],
     gazelle = ":gazelle_bin",
 )
 
@@ -25,4 +28,10 @@ gazelle(
     ],
     command = "update-repos",
     gazelle = ":gazelle_bin",
+)
+
+bzl_library(
+    name = "swift_deps",
+    srcs = ["swift_deps.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/examples/pkg_manifest/BUILD.bazel
+++ b/examples/pkg_manifest/BUILD.bazel
@@ -12,7 +12,7 @@ gazelle_binary(
 )
 
 gazelle(
-    name = "gazelle",
+    name = "update_build_files",
     extra_args = [
         "-gen_from_pkg_manifest",
     ],

--- a/examples/pkg_manifest_test_runner.sh
+++ b/examples/pkg_manifest_test_runner.sh
@@ -45,7 +45,7 @@ bazel info
 bazel run //:swift_update_repos
 
 # Generate build files for the workspace
-bazel run //:gazelle
+bazel run //:update_build_files
 
 # Ensure that it builds
 bazel test //...

--- a/examples/pkg_manifest_test_runner.sh
+++ b/examples/pkg_manifest_test_runner.sh
@@ -41,8 +41,11 @@ cd "${scratch_dir}"
 # Dump Bazel info
 bazel info
 
-# Run gazelle
-bazel run //:gazelle -- --gen_from_pkg_manifest
+# Generate Swift external deps 
+bazel run //:swift_update_repos
+
+# Generate build files for the workspace
+bazel run //:gazelle
 
 # Ensure that it builds
 bazel test //...

--- a/gazelle/internal/jsonutils/json_map.go
+++ b/gazelle/internal/jsonutils/json_map.go
@@ -2,6 +2,7 @@ package jsonutils
 
 import (
 	"encoding/json"
+	"math"
 )
 
 func StringAtKey(jm map[string]any, k string) (string, error) {
@@ -25,6 +26,10 @@ func IntAtKey(jm map[string]any, k string) (int, error) {
 	switch t := rawValue.(type) {
 	case int:
 		return t, nil
+	case float64:
+		// Unmarshal stores all numbers as float64 when unmarshaled to an interface value
+		// https://pkg.go.dev/encoding/json#Unmarshal.
+		return int(math.Round(t)), nil
 	default:
 		return 0, NewKeyTypeError(k, "int", t)
 	}

--- a/gazelle/internal/jsonutils/json_map.go
+++ b/gazelle/internal/jsonutils/json_map.go
@@ -17,6 +17,19 @@ func StringAtKey(jm map[string]any, k string) (string, error) {
 	}
 }
 
+func IntAtKey(jm map[string]any, k string) (int, error) {
+	rawValue, ok := jm[k]
+	if !ok {
+		return 0, NewMissingKeyError(k)
+	}
+	switch t := rawValue.(type) {
+	case int:
+		return t, nil
+	default:
+		return 0, NewKeyTypeError(k, "int", t)
+	}
+}
+
 func MapAtKey(jm map[string]any, k string) (map[string]any, error) {
 	rawValue, ok := jm[k]
 	if !ok {

--- a/gazelle/internal/jsonutils/json_map_test.go
+++ b/gazelle/internal/jsonutils/json_map_test.go
@@ -17,6 +17,7 @@ var structValue map[string]any
 var stringSliceValue = []any{"hello", "goodbye"}
 var intSliceValue = []any{123, 456}
 var intValue = 123
+var stringValue = "stringValue"
 
 func init() {
 	mapValue = make(map[string]any)
@@ -26,7 +27,7 @@ func init() {
 	structValue["name"] = "harry"
 
 	rawMap = make(map[string]any)
-	rawMap["stringKey"] = "stringValue"
+	rawMap["stringKey"] = stringValue
 	rawMap["intKey"] = intValue
 	rawMap["mapKey"] = mapValue
 	rawMap["stringSliceKey"] = stringSliceValue
@@ -51,6 +52,26 @@ func TestStringAtKey(t *testing.T) {
 		actual, err := jsonutils.StringAtKey(rawMap, "stringKey")
 		assert.NoError(t, err)
 		assert.Equal(t, "stringValue", actual)
+	})
+}
+
+func TestIntAtKey(t *testing.T) {
+	t.Run("key does not exist", func(t *testing.T) {
+		k := "doesNotExist"
+		actual, err := jsonutils.IntAtKey(rawMap, k)
+		assert.Equal(t, jsonutils.NewMissingKeyError(k), err)
+		assert.Equal(t, 0, actual)
+	})
+	t.Run("key exists, is not int", func(t *testing.T) {
+		k := "stringKey"
+		actual, err := jsonutils.IntAtKey(rawMap, k)
+		assert.Equal(t, jsonutils.NewKeyTypeError(k, "int", stringValue), err)
+		assert.Equal(t, 0, actual)
+	})
+	t.Run("key exists, is int", func(t *testing.T) {
+		actual, err := jsonutils.IntAtKey(rawMap, "intKey")
+		assert.NoError(t, err)
+		assert.Equal(t, intValue, actual)
 	})
 }
 

--- a/gazelle/internal/jsonutils/json_map_test.go
+++ b/gazelle/internal/jsonutils/json_map_test.go
@@ -18,6 +18,8 @@ var stringSliceValue = []any{"hello", "goodbye"}
 var intSliceValue = []any{123, 456}
 var intValue = 123
 var stringValue = "stringValue"
+var floatValue = float64(2)
+var floatValueAsInt = 2
 
 func init() {
 	mapValue = make(map[string]any)
@@ -33,6 +35,7 @@ func init() {
 	rawMap["stringSliceKey"] = stringSliceValue
 	rawMap["structKey"] = structValue
 	rawMap["intSliceKey"] = intSliceValue
+	rawMap["floatKey"] = floatValue
 }
 
 func TestStringAtKey(t *testing.T) {
@@ -72,6 +75,11 @@ func TestIntAtKey(t *testing.T) {
 		actual, err := jsonutils.IntAtKey(rawMap, "intKey")
 		assert.NoError(t, err)
 		assert.Equal(t, intValue, actual)
+	})
+	t.Run("key exists, is float64", func(t *testing.T) {
+		actual, err := jsonutils.IntAtKey(rawMap, "floatKey")
+		assert.NoError(t, err)
+		assert.Equal(t, floatValueAsInt, actual)
 	})
 }
 

--- a/gazelle/internal/spreso/BUILD.bazel
+++ b/gazelle/internal/spreso/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     ],
     importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/spreso",
     visibility = ["//gazelle:__subpackages__"],
+    deps = ["//gazelle/internal/jsonutils"],
 )
 
 go_test(

--- a/gazelle/internal/spreso/pin.go
+++ b/gazelle/internal/spreso/pin.go
@@ -14,11 +14,6 @@ type Pin struct {
 	State  PinState
 }
 
-func NewPinsFromResolvedPackageFile(path string) ([]*Pin, error) {
-	// TODO(chuck): IMPLEMENT ME!
-	return nil, nil
-}
-
 func NewPinsFromResolvedPackageJSON(b []byte) ([]*Pin, error) {
 	var anyMap map[string]any
 	if err := json.Unmarshal(b, &anyMap); err != nil {

--- a/gazelle/internal/spreso/pin.go
+++ b/gazelle/internal/spreso/pin.go
@@ -7,6 +7,16 @@ type Pin struct {
 	State  PinState
 }
 
+func NewPinsFromResolvedPackageFile(path string) ([]*Pin, error) {
+	// TODO(chuck): IMPLEMENT ME!
+	return nil, nil
+}
+
+func NewPinsFromResolvedPackageJSON(b []byte) ([]*Pin, error) {
+	// TODO(chuck): IMPLEMENT ME!
+	return nil, nil
+}
+
 // PinStateType
 
 type PinStateType int

--- a/gazelle/internal/spreso/pin_test.go
+++ b/gazelle/internal/spreso/pin_test.go
@@ -52,7 +52,10 @@ func TestNewPinsFromResolvedPackageJSON(t *testing.T) {
 		assert.Equal(t, &swiftArgParserPin, pins[0])
 	})
 	t.Run("unrecognized version", func(t *testing.T) {
-		t.Error("IMPLEMENT ME!")
+		unrecognizedJSON := `{"version": 9}`
+		pins, err := spreso.NewPinsFromResolvedPackageJSON([]byte(unrecognizedJSON))
+		assert.ErrorContains(t, err, "unrecognized version 9 for resolved package JSON")
+		assert.Nil(t, pins)
 	})
 }
 

--- a/gazelle/internal/spreso/pin_test.go
+++ b/gazelle/internal/spreso/pin_test.go
@@ -40,7 +40,10 @@ func TestNewRevisionPinState(t *testing.T) {
 
 func TestNewPinsFromResolvedPackageJSON(t *testing.T) {
 	t.Run("v1", func(t *testing.T) {
-		t.Error("IMPLEMENT ME!")
+		pins, err := spreso.NewPinsFromResolvedPackageJSON([]byte(v1PinStoreJSON))
+		assert.NoError(t, err)
+		assert.Len(t, pins, 1)
+		assert.Equal(t, &swiftArgParserPin, pins[0])
 	})
 	t.Run("v2", func(t *testing.T) {
 		t.Error("IMPLEMENT ME!")
@@ -49,3 +52,33 @@ func TestNewPinsFromResolvedPackageJSON(t *testing.T) {
 		t.Error("IMPLEMENT ME!")
 	})
 }
+
+var swiftArgParserPin = spreso.Pin{
+	PkgRef: &spreso.PackageReference{
+		Identity: "swift-argument-parser",
+		Kind:     spreso.RemoteSourceControlPkgRefKind,
+		Location: "https://github.com/apple/swift-argument-parser",
+		Name:     "",
+	},
+	State: &spreso.VersionPinState{
+		Version:  "1.2.0",
+		Revision: "fddd1c00396eed152c45a46bea9f47b98e59301d",
+	},
+}
+
+const v1PinStoreJSON = `
+{
+  "version": 1,
+  "object": {
+	"pins": [
+	  {
+		"repositoryURL": "https://github.com/apple/swift-argument-parser",
+		"state": {
+          "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
+          "version" : "1.2.0"
+		}
+	  }
+	]
+  }
+}
+`

--- a/gazelle/internal/spreso/pin_test.go
+++ b/gazelle/internal/spreso/pin_test.go
@@ -37,3 +37,15 @@ func TestNewRevisionPinState(t *testing.T) {
 	}
 	assert.Equal(t, expected, actual)
 }
+
+func TestNewPinsFromResolvedPackageJSON(t *testing.T) {
+	t.Run("v1", func(t *testing.T) {
+		t.Error("IMPLEMENT ME!")
+	})
+	t.Run("v2", func(t *testing.T) {
+		t.Error("IMPLEMENT ME!")
+	})
+	t.Run("unrecognized version", func(t *testing.T) {
+		t.Error("IMPLEMENT ME!")
+	})
+}

--- a/gazelle/internal/spreso/pin_test.go
+++ b/gazelle/internal/spreso/pin_test.go
@@ -46,7 +46,10 @@ func TestNewPinsFromResolvedPackageJSON(t *testing.T) {
 		assert.Equal(t, &swiftArgParserPin, pins[0])
 	})
 	t.Run("v2", func(t *testing.T) {
-		t.Error("IMPLEMENT ME!")
+		pins, err := spreso.NewPinsFromResolvedPackageJSON([]byte(v2PinStoreJSON))
+		assert.NoError(t, err)
+		assert.Len(t, pins, 1)
+		assert.Equal(t, &swiftArgParserPin, pins[0])
 	})
 	t.Run("unrecognized version", func(t *testing.T) {
 		t.Error("IMPLEMENT ME!")
@@ -80,5 +83,22 @@ const v1PinStoreJSON = `
 	  }
 	]
   }
+}
+`
+
+const v2PinStoreJSON = `
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
+        "version" : "1.2.0"
+      }
+    }
+  ],
+  "version" : 2
 }
 `


### PR DESCRIPTION
- Add `jsonutils.IntAtKey()`
- Add `spreso.NewPinsFromResolvedPackageJSON()` to parse JSON and return the pins. 

Related to #9.