### PR TITLE
chore(`swift_package`): ensure executable targets create a single `swift_binary`

### DIFF
--- a/swiftpkg/internal/lists.bzl
+++ b/swiftpkg/internal/lists.bzl
@@ -1,12 +1,36 @@
 """Module for managing Starlark `list` values."""
 
 def _compact(items):
+    """Returns the provide items with any `None` values removed.
+
+    Args:
+        items: A `list` of items to evaluate.
+
+    Returns:
+        A `list` of items with the `None` values removed.
+    """
     new_items = []
     for item in items:
         if item != None:
             new_items.append(item)
     return new_items
 
+def _contains(items, target):
+    """Determines if the provide value is found in a list.
+
+    Args:
+        items: A `list` of items to evaluate.
+        target: The item that may be contained in the items list.
+
+    Returns:
+        A `bool` indicating whether the target item was found in the list.
+    """
+    for item in items:
+        if item == target:
+            return True
+    return False
+
 lists = struct(
     compact = _compact,
+    contains = _contains,
 )

--- a/swiftpkg/internal/swift_package.bzl
+++ b/swiftpkg/internal/swift_package.bzl
@@ -75,7 +75,7 @@ def _update_git_attrs(orig, keys, override):
 def _gen_build_files(repository_ctx, pkg_info):
     repo_name = repository_ctx.name
 
-    # Create a build file for each Swift package target in their corresponding
+    # Create build files for each Swift package target in their corresponding
     # target path.
     for target in pkg_info.targets:
         bld_file = swiftpkg_build_files.new_for_target(

--- a/swiftpkg/tests/lists_tests.bzl
+++ b/swiftpkg/tests/lists_tests.bzl
@@ -19,8 +19,25 @@ def _compact_test(ctx):
 
 compact_test = unittest.make(_compact_test)
 
+def _contains_test(ctx):
+    env = unittest.begin(ctx)
+
+    actual = lists.contains([], "apple")
+    asserts.false(env, actual)
+
+    actual = lists.contains(["zebra"], "apple")
+    asserts.false(env, actual)
+
+    actual = lists.contains(["zebra", "apple"], "apple")
+    asserts.true(env, actual)
+
+    return unittest.end(env)
+
+contains_test = unittest.make(_contains_test)
+
 def lists_test_suite():
     return unittest.suite(
         "lists_tests",
         compact_test,
+        contains_test,
     )


### PR DESCRIPTION
- Update `swift_package` to generate a single `swift_binary` declaratio for executable targets.
- Add `lists.contains()`.
- Document `lists`.

Related to #9.