### PR TITLE
chore: migrate to `swiftpkg` models

### DIFF
--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -73,9 +73,9 @@ func indexExtDepsInManifest(mi *swift.ModuleIndex, pi *swiftpkg.PackageInfo) {
 	// Create a map of Swift external dep identity and Bazel repo name
 	depIdentToBazelRepoName := make(map[string]string)
 	for _, d := range dump.Dependencies {
-		depIdentToBazelRepoName[d.Name], err = swift.RepoNameFromURL(d.URL)
+		depIdentToBazelRepoName[d.Identity()], err = swift.RepoNameFromURL(d.URL())
 		if err != nil {
-			log.Fatalf("Failed to create repo name for %s: %w", d.Name, err)
+			log.Fatalf("Failed to create repo name for %s: %w", d.Identity(), err)
 		}
 	}
 

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -65,16 +65,16 @@ func genRulesFromSwiftPkg(sc *swiftcfg.SwiftConfig, args language.GenerateArgs) 
 	result := language.GenerateResult{}
 
 	// If we are in the Swift product directory (package root), then generate rules for proudcts
-	if args.Dir == sc.PackageInfo.Dir {
+	if args.Dir == sc.PackageInfo.Path {
 		result.Gen = swift.RulesForSwiftProducts(args, sc.PackageInfo)
 		result.Imports = swift.Imports(result.Gen)
 	}
 
 	// Check if we are in a Swift target directory
-	desc := sc.PackageInfo.DescManifest
-	for _, desct := range desc.Targets {
-		if desct.Path == args.Rel {
-			result.Gen = swift.RulesForSwiftTarget(args, sc.PackageInfo, desct.Name)
+	pi := sc.PackageInfo
+	for _, t := range pi.Targets {
+		if t.Path == args.Rel {
+			result.Gen = swift.RulesForSwiftTarget(args, pi, t.Name)
 			result.Imports = swift.Imports(result.Gen)
 		}
 	}

--- a/gazelle/internal/spdump/BUILD.bazel
+++ b/gazelle/internal/spdump/BUILD.bazel
@@ -23,10 +23,7 @@ go_library(
     ],
     importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/spdump",
     visibility = ["//gazelle:__subpackages__"],
-    deps = [
-        "//gazelle/internal/jsonutils",
-        "@com_github_hashicorp_go_multierror//:go-multierror",
-    ],
+    deps = ["//gazelle/internal/jsonutils"],
 )
 
 go_test(

--- a/gazelle/internal/spdump/dependency.go
+++ b/gazelle/internal/spdump/dependency.go
@@ -2,21 +2,79 @@ package spdump
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/cgrindel/swift_bazel/gazelle/internal/jsonutils"
-	"github.com/hashicorp/go-multierror"
 )
 
 type Dependency struct {
-	// TODO(chuck): Change Name to Identity
-	Name        string
-	URL         string
-	Requirement DependencyRequirement
+	SourceControl *SourceControl `json:"sourceControl"`
+}
+
+func (d *Dependency) Identity() string {
+	if d.SourceControl != nil {
+		return d.SourceControl.Identity
+	}
+	return ""
+}
+
+func (d *Dependency) URL() string {
+	if d.SourceControl != nil {
+		if d.SourceControl.Location.Remote != nil {
+			return d.SourceControl.Location.Remote.URL
+		}
+	}
+	return ""
+}
+
+type srcCtrl struct {
+	Identity    string
+	Location    *SourceControlLocation
+	Requirement *DependencyRequirement
+}
+
+type SourceControl struct {
+	Identity    string
+	Location    *SourceControlLocation
+	Requirement *DependencyRequirement
+}
+
+func (sc *SourceControl) UnmarshalJSON(b []byte) error {
+	var raw []*srcCtrl
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+	rawSC := raw[0]
+	sc.Identity = rawSC.Identity
+	sc.Location = rawSC.Location
+	sc.Requirement = rawSC.Requirement
+	return nil
+}
+
+type SourceControlLocation struct {
+	Remote *RemoteLocation
+}
+
+type RemoteLocation struct {
+	URL string
+}
+
+func (rl *RemoteLocation) UnmarshalJSON(b []byte) error {
+	var raw []any
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+
+	rl.URL, err = jsonutils.StringAtIndex(raw, 0)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 type DependencyRequirement struct {
-	Range []VersionRange
+	Range []*VersionRange
 }
 
 type VersionRange struct {
@@ -24,49 +82,49 @@ type VersionRange struct {
 	UpperBound string
 }
 
-const dependencyLogPrefix = "Decoding Dependency:"
+// const dependencyLogPrefix = "Decoding Dependency:"
 
-func (d *Dependency) UnmarshalJSON(b []byte) error {
-	var errs error
+// func (d *Dependency) UnmarshalJSON(b []byte) error {
+// 	var errs error
 
-	var raw map[string]any
-	err := json.Unmarshal(b, &raw)
-	if err != nil {
-		return err
-	}
+// 	var raw map[string]any
+// 	err := json.Unmarshal(b, &raw)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	srcCtrlList, err := jsonutils.SliceAtKey(raw, "sourceControl")
-	if err != nil {
-		return err
-	}
-	if len(srcCtrlList) == 0 {
-		log.Println(dependencyLogPrefix, "Expected at least one entry in `sourceControl` list.")
-		return nil
-	}
-	srcCtrlEntry := srcCtrlList[0].(map[string]any)
+// 	srcCtrlList, err := jsonutils.SliceAtKey(raw, "sourceControl")
+// 	if err != nil {
+// 		return err
+// 	}
+// 	if len(srcCtrlList) == 0 {
+// 		log.Println(dependencyLogPrefix, "Expected at least one entry in `sourceControl` list.")
+// 		return nil
+// 	}
+// 	srcCtrlEntry := srcCtrlList[0].(map[string]any)
 
-	// Name
-	if d.Name, err = jsonutils.StringAtKey(srcCtrlEntry, "identity"); err != nil {
-		errs = multierror.Append(errs, err)
-	}
+// 	// Name
+// 	if d.Name, err = jsonutils.StringAtKey(srcCtrlEntry, "identity"); err != nil {
+// 		errs = multierror.Append(errs, err)
+// 	}
 
-	// URL
-	if location, err := jsonutils.MapAtKey(srcCtrlEntry, "location"); err == nil {
-		if remotes, err := jsonutils.SliceAtKey(location, "remote"); err == nil {
-			if len(remotes) > 0 {
-				d.URL = remotes[0].(string)
-			}
-		} else {
-			errs = multierror.Append(errs, err)
-		}
-	} else {
-		errs = multierror.Append(errs, err)
-	}
+// 	// URL
+// 	if location, err := jsonutils.MapAtKey(srcCtrlEntry, "location"); err == nil {
+// 		if remotes, err := jsonutils.SliceAtKey(location, "remote"); err == nil {
+// 			if len(remotes) > 0 {
+// 				d.URL = remotes[0].(string)
+// 			}
+// 		} else {
+// 			errs = multierror.Append(errs, err)
+// 		}
+// 	} else {
+// 		errs = multierror.Append(errs, err)
+// 	}
 
-	// Requirement
-	if err = jsonutils.UnmarshalAtKey(srcCtrlEntry, "requirement", &d.Requirement); err != nil {
-		errs = multierror.Append(errs, err)
-	}
+// 	// Requirement
+// 	if err = jsonutils.UnmarshalAtKey(srcCtrlEntry, "requirement", &d.Requirement); err != nil {
+// 		errs = multierror.Append(errs, err)
+// 	}
 
-	return errs
-}
+// 	return errs
+// }

--- a/gazelle/internal/spdump/dependency.go
+++ b/gazelle/internal/spdump/dependency.go
@@ -74,57 +74,10 @@ func (rl *RemoteLocation) UnmarshalJSON(b []byte) error {
 }
 
 type DependencyRequirement struct {
-	Range []*VersionRange
+	Ranges []*VersionRange `json:"range"`
 }
 
 type VersionRange struct {
 	LowerBound string
 	UpperBound string
 }
-
-// const dependencyLogPrefix = "Decoding Dependency:"
-
-// func (d *Dependency) UnmarshalJSON(b []byte) error {
-// 	var errs error
-
-// 	var raw map[string]any
-// 	err := json.Unmarshal(b, &raw)
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	srcCtrlList, err := jsonutils.SliceAtKey(raw, "sourceControl")
-// 	if err != nil {
-// 		return err
-// 	}
-// 	if len(srcCtrlList) == 0 {
-// 		log.Println(dependencyLogPrefix, "Expected at least one entry in `sourceControl` list.")
-// 		return nil
-// 	}
-// 	srcCtrlEntry := srcCtrlList[0].(map[string]any)
-
-// 	// Name
-// 	if d.Name, err = jsonutils.StringAtKey(srcCtrlEntry, "identity"); err != nil {
-// 		errs = multierror.Append(errs, err)
-// 	}
-
-// 	// URL
-// 	if location, err := jsonutils.MapAtKey(srcCtrlEntry, "location"); err == nil {
-// 		if remotes, err := jsonutils.SliceAtKey(location, "remote"); err == nil {
-// 			if len(remotes) > 0 {
-// 				d.URL = remotes[0].(string)
-// 			}
-// 		} else {
-// 			errs = multierror.Append(errs, err)
-// 		}
-// 	} else {
-// 		errs = multierror.Append(errs, err)
-// 	}
-
-// 	// Requirement
-// 	if err = jsonutils.UnmarshalAtKey(srcCtrlEntry, "requirement", &d.Requirement); err != nil {
-// 		errs = multierror.Append(errs, err)
-// 	}
-
-// 	return errs
-// }

--- a/gazelle/internal/spdump/manifest.go
+++ b/gazelle/internal/spdump/manifest.go
@@ -2,7 +2,6 @@ package spdump
 
 import (
 	"encoding/json"
-	"sort"
 )
 
 // The JSON formats described in this file are for the swift package dump-package JSON output.
@@ -24,37 +23,4 @@ type Manifest struct {
 	Platforms    []Platform
 	Products     []Product
 	Targets      Targets
-}
-
-// Returns a uniq slice of the product references used in the manifest
-func (m *Manifest) ProductReferences() []*ProductReference {
-	prs := make(map[string]*ProductReference)
-
-	addProdRef := func(pr *ProductReference) {
-		if pr == nil {
-			return
-		}
-		uk := pr.UniqKey()
-		if _, ok := prs[uk]; !ok {
-			prs[uk] = pr
-		}
-	}
-
-	for _, t := range m.Targets {
-		for _, td := range t.Dependencies {
-			addProdRef(td.Product)
-		}
-	}
-
-	keys := make([]string, 0, len(prs))
-	for k := range prs {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	result := make([]*ProductReference, 0, len(prs))
-	for _, k := range keys {
-		result = append(result, prs[k])
-	}
-	return result
 }

--- a/gazelle/internal/spdump/manifest_test.go
+++ b/gazelle/internal/spdump/manifest_test.go
@@ -12,11 +12,17 @@ func TestNewManifestFromJSON(t *testing.T) {
 		Name: "MySwiftPackage",
 		Dependencies: []spdump.Dependency{
 			{
-				Name: "swift-argument-parser",
-				URL:  "https://github.com/apple/swift-argument-parser",
-				Requirement: spdump.DependencyRequirement{
-					Range: []spdump.VersionRange{
-						{LowerBound: "1.2.0", UpperBound: "2.0.0"},
+				SourceControl: &spdump.SourceControl{
+					Identity: "swift-argument-parser",
+					Location: &spdump.SourceControlLocation{
+						Remote: &spdump.RemoteLocation{
+							URL: "https://github.com/apple/swift-argument-parser",
+						},
+					},
+					Requirement: &spdump.DependencyRequirement{
+						Range: []*spdump.VersionRange{
+							&spdump.VersionRange{LowerBound: "1.2.0", UpperBound: "2.0.0"},
+						},
 					},
 				},
 			},

--- a/gazelle/internal/spdump/manifest_test.go
+++ b/gazelle/internal/spdump/manifest_test.go
@@ -20,7 +20,7 @@ func TestNewManifestFromJSON(t *testing.T) {
 						},
 					},
 					Requirement: &spdump.DependencyRequirement{
-						Range: []*spdump.VersionRange{
+						Ranges: []*spdump.VersionRange{
 							&spdump.VersionRange{LowerBound: "1.2.0", UpperBound: "2.0.0"},
 						},
 					},

--- a/gazelle/internal/spdump/manifest_test.go
+++ b/gazelle/internal/spdump/manifest_test.go
@@ -66,35 +66,6 @@ func TestNewManifestFromJSON(t *testing.T) {
 	assert.Equal(t, expected, manifest)
 }
 
-func TestManifestProductReferences(t *testing.T) {
-	m := spdump.Manifest{
-		Targets: []spdump.Target{
-			{
-				Dependencies: []spdump.TargetDependency{
-					{Product: &spdump.ProductReference{ProductName: "Foo", DependencyName: "repoA"}},
-					{Product: &spdump.ProductReference{ProductName: "Bar", DependencyName: "repoA"}},
-					{Product: &spdump.ProductReference{ProductName: "Chicken", DependencyName: "repoB"}},
-				},
-			},
-			{
-				Dependencies: []spdump.TargetDependency{
-					{Product: &spdump.ProductReference{ProductName: "Foo", DependencyName: "repoA"}},
-					{Product: &spdump.ProductReference{ProductName: "Smidgen", DependencyName: "repoB"}},
-				},
-			},
-		},
-	}
-
-	actual := m.ProductReferences()
-	expected := []*spdump.ProductReference{
-		&spdump.ProductReference{ProductName: "Bar", DependencyName: "repoA"},
-		&spdump.ProductReference{ProductName: "Foo", DependencyName: "repoA"},
-		&spdump.ProductReference{ProductName: "Chicken", DependencyName: "repoB"},
-		&spdump.ProductReference{ProductName: "Smidgen", DependencyName: "repoB"},
-	}
-	assert.Equal(t, expected, actual)
-}
-
 const swiftPackageJSONStr = `
 {
   "cLanguageStandard" : null,

--- a/gazelle/internal/swift/BUILD.bazel
+++ b/gazelle/internal/swift/BUILD.bazel
@@ -27,8 +27,6 @@ go_library(
     visibility = ["//gazelle:__subpackages__"],
     deps = [
         "//gazelle/internal/pathdistance",
-        "//gazelle/internal/spdesc",
-        "//gazelle/internal/spdump",
         "//gazelle/internal/spreso",
         "//gazelle/internal/stringslices",
         "//gazelle/internal/swiftpkg",
@@ -56,8 +54,8 @@ go_test(
     ],
     deps = [
         ":swift",
-        "//gazelle/internal/spdesc",
         "//gazelle/internal/spreso",
+        "//gazelle/internal/swiftpkg",
         "@bazel_gazelle//label:go_default_library",
         "@bazel_gazelle//rule:go_default_library",
         "@com_github_stretchr_testify//assert",

--- a/gazelle/internal/swift/bazel_label.go
+++ b/gazelle/internal/swift/bazel_label.go
@@ -2,10 +2,10 @@ package swift
 
 import (
 	"github.com/bazelbuild/bazel-gazelle/label"
-	"github.com/cgrindel/swift_bazel/gazelle/internal/spdesc"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg"
 )
 
-func BazelLabelFromTarget(repoName string, target *spdesc.Target) string {
+func BazelLabelFromTarget(repoName string, target *swiftpkg.Target) string {
 	lbl := label.New(repoName, target.Path, target.Name)
 	return lbl.String()
 }

--- a/gazelle/internal/swift/bazel_label_test.go
+++ b/gazelle/internal/swift/bazel_label_test.go
@@ -3,13 +3,13 @@ package swift_test
 import (
 	"testing"
 
-	"github.com/cgrindel/swift_bazel/gazelle/internal/spdesc"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBazelLabelFromTarget(t *testing.T) {
-	target := &spdesc.Target{
+	target := &swiftpkg.Target{
 		Name: "Foo",
 		Path: "Sources/Foo",
 	}

--- a/gazelle/internal/swift/rules_from_manifest.go
+++ b/gazelle/internal/swift/rules_from_manifest.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/language"
 	"github.com/bazelbuild/bazel-gazelle/rule"
-	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg"
 )
 
 func RulesForSwiftProducts(args language.GenerateArgs, pi *swiftpkg.PackageInfo) []*rule.Rule {
 	var rules []*rule.Rule
-	for _, prd := range pi.DumpManifest.Products {
-		prdRules := rulesForSwiftProduct(args, pi, &prd)
+	for _, prd := range pi.Products {
+		prdRules := rulesForSwiftProduct(args, pi, prd)
 		rules = append(rules, prdRules...)
 	}
 	return rules
@@ -21,14 +20,14 @@ func RulesForSwiftProducts(args language.GenerateArgs, pi *swiftpkg.PackageInfo)
 func rulesForSwiftProduct(
 	args language.GenerateArgs,
 	pi *swiftpkg.PackageInfo,
-	product *spdump.Product,
+	product *swiftpkg.Product,
 ) []*rule.Rule {
 	if len(product.Targets) == 0 {
 		log.Printf("No targets found in product %s while generating rules.", product.Name)
 		return nil
 	}
 	targetName := product.Targets[0]
-	target := pi.DescManifest.Targets.FindByName(targetName)
+	target := pi.Targets.FindByName(targetName)
 	if target == nil {
 		log.Printf("Target with name %s not found while generating rules for %s product.",
 			targetName, product.Name)
@@ -40,22 +39,16 @@ func rulesForSwiftProduct(
 }
 
 func RulesForSwiftTarget(args language.GenerateArgs, pi *swiftpkg.PackageInfo, targetName string) []*rule.Rule {
-	dump := pi.DumpManifest
-	desc := pi.DescManifest
 	shouldSetVis := shouldSetVisibility(args)
-
-	dumpt := dump.Targets.FindByName(targetName)
-	desct := desc.Targets.FindByName(dumpt.Name)
-	srcs := desct.Sources
-
+	t := pi.Targets.FindByName(targetName)
 	var rules []*rule.Rule
-	switch dumpt.Type {
-	case spdump.LibraryTargetType:
-		rules = rulesForLibraryModule(dumpt.Name, srcs, dumpt.Imports(), shouldSetVis)
-	case spdump.ExecutableTargetType:
-		rules = rulesForBinaryModule(dumpt.Name, srcs, dumpt.Imports(), shouldSetVis)
-	case spdump.TestTargetType:
-		rules = rulesForTestModule(dumpt.Name, srcs, dumpt.Imports(), shouldSetVis)
+	switch t.Type {
+	case swiftpkg.LibraryTargetType:
+		rules = rulesForLibraryModule(t.Name, t.Sources, t.Imports(), shouldSetVis)
+	case swiftpkg.ExecutableTargetType:
+		rules = rulesForBinaryModule(t.Name, t.Sources, t.Imports(), shouldSetVis)
+	case swiftpkg.TestTargetType:
+		rules = rulesForTestModule(t.Name, t.Sources, t.Imports(), shouldSetVis)
 	}
 	return rules
 }

--- a/gazelle/internal/swiftcfg/BUILD.bazel
+++ b/gazelle/internal/swiftcfg/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
     ],
     deps = [
         ":swiftcfg",
-        "//gazelle/internal/spdesc",
         "//gazelle/internal/swiftbin",
         "//gazelle/internal/swiftpkg",
         "@bazel_gazelle//config:go_default_library",

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -39,9 +39,9 @@ func (sc *SwiftConfig) GenerateRulesMode(args language.GenerateArgs) GenerateRul
 	pi := sc.PackageInfo
 	if pi == nil {
 		return SrcFileGenRulesMode
-	} else if args.Dir == pi.Dir {
+	} else if args.Dir == pi.Path {
 		return SwiftPkgGenRulesMode
-	} else if desct := pi.DescManifest.Targets.FindByPath(args.Rel); desct != nil {
+	} else if desct := pi.Targets.FindByPath(args.Rel); desct != nil {
 		return SwiftPkgGenRulesMode
 	}
 	return SkipGenRulesMode

--- a/gazelle/internal/swiftcfg/swift_config_test.go
+++ b/gazelle/internal/swiftcfg/swift_config_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/cgrindel/swift_bazel/gazelle/internal/spdesc"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftbin"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftcfg"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg"
@@ -30,26 +29,24 @@ func TestSwiftConfigSwiftBin(t *testing.T) {
 func TestSwiftConfigGenerateRulesMode(t *testing.T) {
 	sc := swiftcfg.NewSwiftConfig()
 	pi := &swiftpkg.PackageInfo{
-		Dir: "/path/to/pkg",
-		DescManifest: &spdesc.Manifest{
-			Targets: spdesc.Targets{
-				{Name: "Foo", Path: "Sources/Target"},
-			},
+		Path: "/path/to/pkg",
+		Targets: swiftpkg.Targets{
+			&swiftpkg.Target{Name: "Foo", Path: "Sources/Target"},
 		},
 	}
 	sc.PackageInfo = pi
 
 	t.Run("no package info", func(t *testing.T) {
 		nopkgSc := swiftcfg.NewSwiftConfig()
-		args := language.GenerateArgs{Dir: pi.Dir}
+		args := language.GenerateArgs{Dir: pi.Path}
 		assert.Equal(t, swiftcfg.SrcFileGenRulesMode, nopkgSc.GenerateRulesMode(args))
 	})
 	t.Run("has package info, args Dir is the package dir", func(t *testing.T) {
-		args := language.GenerateArgs{Dir: pi.Dir, Rel: ""}
+		args := language.GenerateArgs{Dir: pi.Path, Rel: ""}
 		assert.Equal(t, swiftcfg.SwiftPkgGenRulesMode, sc.GenerateRulesMode(args))
 	})
 	t.Run("has package info, not package dir, is target dir", func(t *testing.T) {
-		args := language.GenerateArgs{Dir: pi.DescManifest.Targets[0].Path, Rel: "Sources/Target"}
+		args := language.GenerateArgs{Dir: pi.Targets[0].Path, Rel: "Sources/Target"}
 		assert.Equal(t, swiftcfg.SwiftPkgGenRulesMode, sc.GenerateRulesMode(args))
 	})
 	t.Run("has package info, not package dir, not target dir", func(t *testing.T) {

--- a/gazelle/internal/swiftpkg/BUILD.bazel
+++ b/gazelle/internal/swiftpkg/BUILD.bazel
@@ -4,8 +4,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "swiftpkg",
     srcs = [
+        "dependency.go",
         "exported_targets.go",
         "package_info.go",
+        "platform.go",
+        "product.go",
+        "target.go",
+        "target_dependency.go",
     ],
     importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg",
     visibility = ["//gazelle:__subpackages__"],

--- a/gazelle/internal/swiftpkg/dependency.go
+++ b/gazelle/internal/swiftpkg/dependency.go
@@ -1,8 +1,30 @@
 package swiftpkg
 
+import (
+	"log"
+
+	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
+)
+
 type Dependency struct {
+	SourceControl *SourceControl
+}
+
+func (d *Dependency) Identity() string {
+	if d.SourceControl != nil {
+		return d.SourceControl.Identity
+	}
+	log.Fatalf("Identity could not be determined.")
+	return ""
+}
+
+func NewDependencyFromManifestInfo(dumpD *spdump.Dependency) (*Dependency, error) {
+	// TODO(chuck): IMPLEMENT ME!
+	return nil, nil
+}
+
+type SourceControl struct {
 	Identity    string
-	Type        string
 	URL         string
 	Requirement DependencyRequirement
 }

--- a/gazelle/internal/swiftpkg/dependency.go
+++ b/gazelle/internal/swiftpkg/dependency.go
@@ -10,6 +10,13 @@ type Dependency struct {
 	SourceControl *SourceControl
 }
 
+func NewDependencyFromManifestInfo(dumpD *spdump.Dependency) (*Dependency, error) {
+	srcCtrl := NewSourceControlFromManifestInfo(dumpD.SourceControl)
+	return &Dependency{
+		SourceControl: srcCtrl,
+	}, nil
+}
+
 func (d *Dependency) Identity() string {
 	if d.SourceControl != nil {
 		return d.SourceControl.Identity
@@ -18,24 +25,69 @@ func (d *Dependency) Identity() string {
 	return ""
 }
 
-func NewDependencyFromManifestInfo(dumpD *spdump.Dependency) (*Dependency, error) {
-	// TODO(chuck): IMPLEMENT ME!
-	return nil, nil
-}
+// SourceControl
 
 type SourceControl struct {
 	Identity    string
-	URL         string
-	Requirement DependencyRequirement
+	Location    *SourceControlLocation
+	Requirement *DependencyRequirement
 }
 
-// Requirement
+func NewSourceControlFromManifestInfo(dumpSC *spdump.SourceControl) *SourceControl {
+	return &SourceControl{
+		Identity:    dumpSC.Identity,
+		Location:    NewSourceControlLocationFromManifestInfo(dumpSC.Location),
+		Requirement: NewDependencyRequirementFromManifestInfo(dumpSC.Requirement),
+	}
+}
+
+type SourceControlLocation struct {
+	Remote *RemoteLocation
+}
+
+func NewSourceControlLocationFromManifestInfo(dumpL *spdump.SourceControlLocation) *SourceControlLocation {
+	return &SourceControlLocation{
+		Remote: NewRemoteLocationFromManifestInfo(dumpL.Remote),
+	}
+}
+
+type RemoteLocation struct {
+	URL string
+}
+
+func NewRemoteLocationFromManifestInfo(rl *spdump.RemoteLocation) *RemoteLocation {
+	return &RemoteLocation{
+		URL: rl.URL,
+	}
+}
+
+// DependencyRequirement
 
 type DependencyRequirement struct {
-	Range []VersionRange
+	Ranges []*VersionRange
 }
+
+func NewDependencyRequirementFromManifestInfo(dr *spdump.DependencyRequirement) *DependencyRequirement {
+	ranges := make([]*VersionRange, len(dr.Ranges))
+	for idx, r := range dr.Ranges {
+		ranges[idx] = NewVersionRangeFromManifestInfo(r)
+	}
+
+	return &DependencyRequirement{
+		Ranges: ranges,
+	}
+}
+
+// VersionRange
 
 type VersionRange struct {
 	LowerBound string
 	UpperBound string
+}
+
+func NewVersionRangeFromManifestInfo(vr *spdump.VersionRange) *VersionRange {
+	return &VersionRange{
+		LowerBound: vr.LowerBound,
+		UpperBound: vr.UpperBound,
+	}
 }

--- a/gazelle/internal/swiftpkg/dependency.go
+++ b/gazelle/internal/swiftpkg/dependency.go
@@ -1,0 +1,19 @@
+package swiftpkg
+
+type Dependency struct {
+	Identity    string
+	Type        string
+	URL         string
+	Requirement DependencyRequirement
+}
+
+// Requirement
+
+type DependencyRequirement struct {
+	Range []VersionRange
+}
+
+type VersionRange struct {
+	LowerBound string
+	UpperBound string
+}

--- a/gazelle/internal/swiftpkg/dependency.go
+++ b/gazelle/internal/swiftpkg/dependency.go
@@ -25,6 +25,18 @@ func (d *Dependency) Identity() string {
 	return ""
 }
 
+func (d *Dependency) URL() string {
+	if d.SourceControl != nil {
+		if d.SourceControl.Location != nil {
+			if d.SourceControl.Location.Remote != nil {
+				return d.SourceControl.Location.Remote.URL
+			}
+		}
+	}
+	log.Fatalf("URL could not be determined.")
+	return ""
+}
+
 // SourceControl
 
 type SourceControl struct {

--- a/gazelle/internal/swiftpkg/exported_targets.go
+++ b/gazelle/internal/swiftpkg/exported_targets.go
@@ -2,23 +2,19 @@ package swiftpkg
 
 import (
 	"fmt"
-
-	"github.com/cgrindel/swift_bazel/gazelle/internal/spdesc"
 )
 
 // GH010: Add test for ExportedTargets
 
 // Targets that are made available outside of the package via a Product reference.
-func (pi *PackageInfo) ExportedTargets() ([]*spdesc.Target, error) {
-	m := pi.DescManifest
-
-	exported := make([]*spdesc.Target, len(m.Products))
-	for idx, p := range m.Products {
+func (pi *PackageInfo) ExportedTargets() ([]*Target, error) {
+	exported := make([]*Target, len(pi.Products))
+	for idx, p := range pi.Products {
 		if len(p.Targets) == 0 {
 			return nil, fmt.Errorf("product %s has no targets", p.Name)
 		}
 		targetName := p.Targets[0]
-		t := m.Targets.FindByName(targetName)
+		t := pi.Targets.FindByName(targetName)
 		if t == nil {
 			return nil, fmt.Errorf(
 				"target %s not found while generating exported targets", targetName)

--- a/gazelle/internal/swiftpkg/package_info.go
+++ b/gazelle/internal/swiftpkg/package_info.go
@@ -1,6 +1,8 @@
 package swiftpkg
 
 import (
+	"fmt"
+
 	"github.com/cgrindel/swift_bazel/gazelle/internal/spdesc"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftbin"
@@ -15,6 +17,16 @@ type PackageInfo struct {
 
 	// Info from the describe
 	DescManifest *spdesc.Manifest
+
+	// Package attributes from manifests
+	Name         string
+	DisplayName  string
+	Path         string
+	ToolsVersion string
+	Targets      Targets
+	Platforms    []Platform
+	Products     []Product
+	Dependencies []Dependency
 }
 
 func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
@@ -36,9 +48,27 @@ func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
 		return nil, err
 	}
 
+	targets := make([]*Target, len(descManifest.Targets))
+	for idx, descT := range descManifest.Targets {
+		dumpT := dumpManifest.Targets.FindByName(descT.Name)
+		if dumpT == nil {
+			return nil, fmt.Errorf("dump manifest info for %s target not found", descT.Name)
+		}
+		targets[idx], err = NewTargetFromManifestInfo(&descT, dumpT)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create target for %s: %w", descT.Name, err)
+		}
+	}
+
 	return &PackageInfo{
+		// TODO(chuck): Remove Dir, DumpManifest, DescManifest
 		Dir:          dir,
 		DumpManifest: dumpManifest,
 		DescManifest: descManifest,
+		Name:         descManifest.Name,
+		DisplayName:  descManifest.ManifestDisplayName,
+		Path:         descManifest.Path,
+		ToolsVersion: descManifest.ToolsVersion,
+		Targets:      targets,
 	}, nil
 }

--- a/gazelle/internal/swiftpkg/package_info.go
+++ b/gazelle/internal/swiftpkg/package_info.go
@@ -85,5 +85,7 @@ func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
 		Targets:      targets,
 		Platforms:    platforms,
 		Products:     products,
+		// TODO(chuck): IMPLEMENT ME!
+		// Dependencies: deps,
 	}, nil
 }

--- a/gazelle/internal/swiftpkg/package_info.go
+++ b/gazelle/internal/swiftpkg/package_info.go
@@ -73,6 +73,14 @@ func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
 		}
 	}
 
+	deps := make([]*Dependency, len(dumpManifest.Dependencies))
+	for idx, d := range dumpManifest.Dependencies {
+		deps[idx], err = NewDependencyFromManifestInfo(&d)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create dependency: %w", err)
+		}
+	}
+
 	return &PackageInfo{
 		// TODO(chuck): Remove Dir, DumpManifest, DescManifest
 		Dir:          dir,
@@ -85,7 +93,6 @@ func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
 		Targets:      targets,
 		Platforms:    platforms,
 		Products:     products,
-		// TODO(chuck): IMPLEMENT ME!
-		// Dependencies: deps,
+		Dependencies: deps,
 	}, nil
 }

--- a/gazelle/internal/swiftpkg/package_info.go
+++ b/gazelle/internal/swiftpkg/package_info.go
@@ -24,9 +24,9 @@ type PackageInfo struct {
 	Path         string
 	ToolsVersion string
 	Targets      Targets
-	Platforms    []Platform
-	Products     []Product
-	Dependencies []Dependency
+	Platforms    []*Platform
+	Products     []*Product
+	Dependencies []*Dependency
 }
 
 func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
@@ -60,6 +60,19 @@ func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
 		}
 	}
 
+	platforms := make([]*Platform, len(descManifest.Platforms))
+	for idx, p := range descManifest.Platforms {
+		platforms[idx] = NewPlatfromFromManifestInfo(&p)
+	}
+
+	products := make([]*Product, len(dumpManifest.Products))
+	for idx, p := range dumpManifest.Products {
+		products[idx], err = NewProductFromManifestInfo(&p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create product for %v: %w", p.Name, err)
+		}
+	}
+
 	return &PackageInfo{
 		// TODO(chuck): Remove Dir, DumpManifest, DescManifest
 		Dir:          dir,
@@ -70,5 +83,7 @@ func NewPackageInfo(sw swiftbin.Executor, dir string) (*PackageInfo, error) {
 		Path:         descManifest.Path,
 		ToolsVersion: descManifest.ToolsVersion,
 		Targets:      targets,
+		Platforms:    platforms,
+		Products:     products,
 	}, nil
 }

--- a/gazelle/internal/swiftpkg/package_info_test.go
+++ b/gazelle/internal/swiftpkg/package_info_test.go
@@ -28,8 +28,35 @@ func TestPackageInfo(t *testing.T) {
 
 		pi, err := swiftpkg.NewPackageInfo(sb, dir)
 		assert.NoError(t, err)
-		assert.Equal(t, dir, pi.Dir)
-		assert.Equal(t, pkgName, pi.DumpManifest.Name)
-		assert.Equal(t, pkgName, pi.DescManifest.Name)
+		assert.Equal(t, pkgName, pi.Name)
 	})
+}
+
+func TestManifestProductReferences(t *testing.T) {
+	m := swiftpkg.PackageInfo{
+		Targets: []*swiftpkg.Target{
+			&swiftpkg.Target{
+				Dependencies: []*swiftpkg.TargetDependency{
+					&swiftpkg.TargetDependency{Product: &swiftpkg.ProductReference{ProductName: "Foo", Identity: "repoA"}},
+					&swiftpkg.TargetDependency{Product: &swiftpkg.ProductReference{ProductName: "Bar", Identity: "repoA"}},
+					&swiftpkg.TargetDependency{Product: &swiftpkg.ProductReference{ProductName: "Chicken", Identity: "repoB"}},
+				},
+			},
+			&swiftpkg.Target{
+				Dependencies: []*swiftpkg.TargetDependency{
+					&swiftpkg.TargetDependency{Product: &swiftpkg.ProductReference{ProductName: "Foo", Identity: "repoA"}},
+					&swiftpkg.TargetDependency{Product: &swiftpkg.ProductReference{ProductName: "Smidgen", Identity: "repoB"}},
+				},
+			},
+		},
+	}
+
+	actual := m.ProductReferences()
+	expected := []*swiftpkg.ProductReference{
+		&swiftpkg.ProductReference{ProductName: "Bar", Identity: "repoA"},
+		&swiftpkg.ProductReference{ProductName: "Foo", Identity: "repoA"},
+		&swiftpkg.ProductReference{ProductName: "Chicken", Identity: "repoB"},
+		&swiftpkg.ProductReference{ProductName: "Smidgen", Identity: "repoB"},
+	}
+	assert.Equal(t, expected, actual)
 }

--- a/gazelle/internal/swiftpkg/platform.go
+++ b/gazelle/internal/swiftpkg/platform.go
@@ -1,6 +1,15 @@
 package swiftpkg
 
+import "github.com/cgrindel/swift_bazel/gazelle/internal/spdesc"
+
 type Platform struct {
 	Name    string
 	Version string
+}
+
+func NewPlatfromFromManifestInfo(descP *spdesc.Platform) *Platform {
+	return &Platform{
+		Name:    descP.Name,
+		Version: descP.Version,
+	}
 }

--- a/gazelle/internal/swiftpkg/platform.go
+++ b/gazelle/internal/swiftpkg/platform.go
@@ -1,0 +1,6 @@
+package swiftpkg
+
+type Platform struct {
+	Name    string
+	Version string
+}

--- a/gazelle/internal/swiftpkg/product.go
+++ b/gazelle/internal/swiftpkg/product.go
@@ -1,0 +1,16 @@
+package swiftpkg
+
+type ProductType int
+
+const (
+	UnknownProductType ProductType = iota
+	ExecutableProductType
+	LibraryProductType
+	PluginProductType
+)
+
+type Product struct {
+	Name    string
+	Targets []string
+	Type    ProductType
+}

--- a/gazelle/internal/swiftpkg/product.go
+++ b/gazelle/internal/swiftpkg/product.go
@@ -1,5 +1,11 @@
 package swiftpkg
 
+import (
+	"fmt"
+
+	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
+)
+
 type ProductType int
 
 const (
@@ -13,4 +19,26 @@ type Product struct {
 	Name    string
 	Targets []string
 	Type    ProductType
+}
+
+func NewProductFromManifestInfo(dumpP *spdump.Product) (*Product, error) {
+	var prdType ProductType
+	switch dumpP.Type {
+	case spdump.UnknownProductType:
+		prdType = UnknownProductType
+	case spdump.ExecutableProductType:
+		prdType = ExecutableProductType
+	case spdump.LibraryProductType:
+		prdType = LibraryProductType
+	case spdump.PluginProductType:
+		prdType = PluginProductType
+	default:
+		return nil, fmt.Errorf(
+			"unrecognized product type %v for %s product", dumpP.Type, dumpP.Name)
+	}
+	return &Product{
+		Name:    dumpP.Name,
+		Targets: dumpP.Targets,
+		Type:    prdType,
+	}, nil
 }

--- a/gazelle/internal/swiftpkg/target.go
+++ b/gazelle/internal/swiftpkg/target.go
@@ -1,0 +1,89 @@
+package swiftpkg
+
+import (
+	"fmt"
+
+	"github.com/cgrindel/swift_bazel/gazelle/internal/spdesc"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
+)
+
+// TargetType
+
+type TargetType int
+
+const (
+	UnknownTargetType TargetType = iota
+	ExecutableTargetType
+	LibraryTargetType
+	TestTargetType
+)
+
+// Targets
+
+type Targets []*Target
+
+func (ts Targets) FindByName(name string) *Target {
+	for _, t := range ts {
+		if t.Name == name {
+			return t
+		}
+	}
+	return nil
+}
+
+func (ts Targets) FindByPath(path string) *Target {
+	for _, t := range ts {
+		if t.Path == path {
+			return t
+		}
+	}
+	return nil
+}
+
+// Target
+
+type Target struct {
+	Name         string
+	C99name      string
+	Type         TargetType
+	ModuleType   string
+	Path         string
+	Sources      []string
+	Dependencies []*TargetDependency
+}
+
+func NewTargetFromManifestInfo(descT *spdesc.Target, dumpT *spdump.Target) (*Target, error) {
+	var targetType TargetType
+	switch dumpT.Type {
+	case spdump.UnknownTargetType:
+		targetType = UnknownTargetType
+	case spdump.ExecutableTargetType:
+		targetType = ExecutableTargetType
+	case spdump.LibraryTargetType:
+		targetType = LibraryTargetType
+	case spdump.TestTargetType:
+		targetType = TestTargetType
+	default:
+		return nil, fmt.Errorf(
+			"unrecognized spdump.TargetType %v for %s target", dumpT.Type, dumpT.Name)
+	}
+
+	var err error
+	tdeps := make([]*TargetDependency, len(dumpT.Dependencies))
+	for idx, td := range dumpT.Dependencies {
+		tdeps[idx], err = NewTargetDependencyFromManifestInfo(&td)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating target dep for %s: %w", dumpT.Name, err)
+		}
+	}
+
+	return &Target{
+		Name:         descT.Name,
+		C99name:      descT.C99name,
+		Type:         targetType,
+		ModuleType:   descT.ModuleType,
+		Path:         descT.Path,
+		Sources:      descT.Sources,
+		Dependencies: tdeps,
+	}, nil
+}

--- a/gazelle/internal/swiftpkg/target.go
+++ b/gazelle/internal/swiftpkg/target.go
@@ -87,3 +87,11 @@ func NewTargetFromManifestInfo(descT *spdesc.Target, dumpT *spdump.Target) (*Tar
 		Dependencies: tdeps,
 	}, nil
 }
+
+func (t *Target) Imports() []string {
+	imports := make([]string, len(t.Dependencies))
+	for idx, td := range t.Dependencies {
+		imports[idx] = td.ImportName()
+	}
+	return imports
+}

--- a/gazelle/internal/swiftpkg/target_dependency.go
+++ b/gazelle/internal/swiftpkg/target_dependency.go
@@ -1,0 +1,71 @@
+package swiftpkg
+
+import (
+	"fmt"
+
+	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
+)
+
+type TargetDependency struct {
+	Product *ProductReference
+	ByName  *ByNameReference
+}
+
+func NewTargetDependencyFromManifestInfo(dumpTD *spdump.TargetDependency) (*TargetDependency, error) {
+	var prodRef *ProductReference
+	var byNameRef *ByNameReference
+	if dumpTD.Product != nil {
+		prodRef = NewProductReferenceFromManifestInfo(dumpTD.Product)
+	} else if dumpTD.ByName != nil {
+		byNameRef = NewByNameReferenceFromManifestInfo(dumpTD.ByName)
+	} else {
+		return nil, fmt.Errorf("invalid target dependency")
+	}
+	return &TargetDependency{
+		Product: prodRef,
+		ByName:  byNameRef,
+	}, nil
+}
+
+func (td *TargetDependency) ImportName() string {
+	if td.Product != nil {
+		return td.Product.ProductName
+	} else if td.ByName != nil {
+		return td.ByName.TargetName
+	}
+	return ""
+}
+
+// ProductReference
+
+// Reference a product
+type ProductReference struct {
+	// Product name
+	ProductName string
+	// External dependency identity
+	Identity string
+}
+
+func NewProductReferenceFromManifestInfo(dumpPR *spdump.ProductReference) *ProductReference {
+	return &ProductReference{
+		ProductName: dumpPR.ProductName,
+		Identity:    dumpPR.DependencyName,
+	}
+}
+
+func (pr *ProductReference) UniqKey() string {
+	return fmt.Sprintf("%s-%s", pr.Identity, pr.ProductName)
+}
+
+// ByNameReference
+
+// Reference a target by name
+type ByNameReference struct {
+	TargetName string
+}
+
+func NewByNameReferenceFromManifestInfo(dumpBNR *spdump.ByNameReference) *ByNameReference {
+	return &ByNameReference{
+		TargetName: dumpBNR.TargetName,
+	}
+}

--- a/gazelle/update_repos.go
+++ b/gazelle/update_repos.go
@@ -61,7 +61,7 @@ func importReposFromPackageManifest(args language.ImportReposArgs) language.Impo
 	// Key: External dependency identity
 	// Value: Pointer to the dependency's package info
 	depPkgInfoMap := make(map[string]*swiftpkg.PackageInfo)
-	for _, dep := range pi.DumpManifest.Dependencies {
+	for _, dep := range pi.Dependencies {
 		depDir := filepath.Join(pkgDir, swiftPkgBuildDirname, swiftPkgCheckoutsDirname, dep.Identity())
 		if err != nil {
 			result.Error = err

--- a/gazelle/update_repos.go
+++ b/gazelle/update_repos.go
@@ -62,7 +62,7 @@ func importReposFromPackageManifest(args language.ImportReposArgs) language.Impo
 	// Value: Pointer to the dependency's package info
 	depPkgInfoMap := make(map[string]*swiftpkg.PackageInfo)
 	for _, dep := range pi.DumpManifest.Dependencies {
-		depDir := filepath.Join(pkgDir, swiftPkgBuildDirname, swiftPkgCheckoutsDirname, dep.Name)
+		depDir := filepath.Join(pkgDir, swiftPkgBuildDirname, swiftPkgCheckoutsDirname, dep.Identity())
 		if err != nil {
 			result.Error = err
 			return result
@@ -72,7 +72,7 @@ func importReposFromPackageManifest(args language.ImportReposArgs) language.Impo
 			result.Error = err
 			return result
 		}
-		depPkgInfoMap[dep.Name] = depPkgInfo
+		depPkgInfoMap[dep.Identity()] = depPkgInfo
 	}
 
 	resolvedPkgPath := filepath.Join(pkgDir, resolvedPkgBasename)

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,12 @@ go 1.19
 require (
 	github.com/bazelbuild/bazel-gazelle v0.28.0
 	github.com/bazelbuild/buildtools v0.0.0-20221004120235-7186f635531b
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/tools v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,10 +32,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -139,20 +139,6 @@ def swift_bazel_go_dependencies():
         sum = "h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=",
         version = "v0.5.9",
     )
-    go_repository(
-        name = "com_github_hashicorp_errwrap",
-        build_external = "external",
-        importpath = "github.com/hashicorp/errwrap",
-        sum = "h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=",
-        version = "v1.0.0",
-    )
-    go_repository(
-        name = "com_github_hashicorp_go_multierror",
-        build_external = "external",
-        importpath = "github.com/hashicorp/go-multierror",
-        sum = "h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=",
-        version = "v1.1.1",
-    )
 
     go_repository(
         name = "com_github_pelletier_go_toml",


### PR DESCRIPTION
- Introduce package info models in `swiftpkg`.
- Switch to use new models.

Closes #61.