### PR TITLE
chore: add clean test for each example workspace

### DIFF
--- a/examples/http_archive_ext_deps/set_up_clean_test
+++ b/examples/http_archive_ext_deps/set_up_clean_test
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
+
+# Remove all build files
+find "${script_dir}" -name "BUILD.bazel" -exec rm {} \;
+
+# Add back a minimal build file at the root
+cat > "${script_dir}/BUILD.bazel"  <<-EOF
+load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
+load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+
+tidy(
+    name = "tidy",
+    targets = [
+        ":update_build_files",
+    ],
+)
+
+# MARK: - Gazelle
+
+gazelle_binary(
+    name = "gazelle_bin",
+    languages = [
+        "@bazel_skylib//gazelle/bzl",
+        "@cgrindel_swift_bazel//gazelle",
+    ],
+)
+
+# gazelle:prefix github.com/cgrindel/swift_bazel/examples/http_archive_ext_deps
+gazelle(
+    name = "update_build_files",
+    gazelle = ":gazelle_bin",
+)
+EOF

--- a/examples/http_archive_ext_deps_test_runner.sh
+++ b/examples/http_archive_ext_deps_test_runner.sh
@@ -36,17 +36,26 @@ workspace_dir="${BIT_WORKSPACE_DIR:-}"
 scratch_dir="$("${create_scratch_dir_sh}" --workspace "${workspace_dir}")"
 cd "${scratch_dir}"
 
-# MARK - Test
-
 # Dump Bazel info
 bazel info
 
-# Run update build files
-bazel run //:tidy
+do_test() {
+  # Run update build files
+  bazel run //:tidy
 
-# Ensure that it builds
-bazel test //...
+  # Ensure that it builds
+  bazel test //...
 
-# Run PrintStuff
-output="$(bazel run //Sources/PrintStuff)"
-assert_match "My deque colors" "${output}" 
+  # Run PrintStuff
+  output="$(bazel run //Sources/PrintStuff)"
+  assert_match "My deque colors" "${output}" 
+}
+
+# MARK - Test As Is
+
+do_test
+
+# MARK - Clean Test
+
+set_up_clean_test
+do_test

--- a/examples/pkg_manifest_minimal/set_up_clean_test
+++ b/examples/pkg_manifest_minimal/set_up_clean_test
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
+
+# Remove all build files
+find "${script_dir}" -name "BUILD.bazel" -exec rm {} \;
+
+# Replace the swift_deps.bzl with no declarations.
+cat > "${script_dir}/swift_deps.bzl"  <<-EOF
+def swift_dependencies():
+    pass
+EOF
+
+# Add back a minimal build file at the root
+cat > "${script_dir}/BUILD.bazel"  <<-EOF
+load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+
+tidy(
+    name = "tidy",
+    targets = [
+        ":swift_update_repos",
+        ":update_build_files",
+    ],
+)
+
+# MARK: - Gazelle
+
+# Ignore the Swift build folder
+# gazelle:exclude .build
+
+gazelle_binary(
+    name = "gazelle_bin",
+    languages = [
+        "@bazel_skylib//gazelle/bzl",
+        "@cgrindel_swift_bazel//gazelle",
+    ],
+)
+
+gazelle(
+    name = "update_build_files",
+    gazelle = ":gazelle_bin",
+)
+
+gazelle(
+    name = "swift_update_repos",
+    args = [
+        "-from_file=Package.swift",
+        "-to_macro=swift_deps.bzl%swift_dependencies",
+        "-prune",
+    ],
+    command = "update-repos",
+    gazelle = ":gazelle_bin",
+)
+
+bzl_library(
+    name = "swift_deps",
+    srcs = ["swift_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@cgrindel_swift_bazel//swiftpkg:defs"],
+)
+EOF

--- a/examples/pkg_manifest_minimal_test_runner.sh
+++ b/examples/pkg_manifest_minimal_test_runner.sh
@@ -36,20 +36,26 @@ workspace_dir="${BIT_WORKSPACE_DIR:-}"
 scratch_dir="$("${create_scratch_dir_sh}" --workspace "${workspace_dir}")"
 cd "${scratch_dir}"
 
-# MARK - Test
-
 # Dump Bazel info
 bazel info
 
-# Generate Swift external deps 
-bazel run //:swift_update_repos
+do_test() {
+  # Generate Swift external deps and update build files
+  bazel run //:tidy
 
-# Generate build files for the workspace
-bazel run //:update_build_files
+  # Ensure that it builds
+  bazel test //...
 
-# Ensure that it builds
-bazel test //...
+  # Run the product alias
+  output="$(bazel run //Sources/MyExecutable)"
+  assert_match "Hello, World!" "${output}" 
+}
 
-# Run the product alias
-output="$(bazel run //Sources/MyExecutable)"
-assert_match "Hello, World!" "${output}" 
+# MARK - Test As Is
+
+do_test
+
+# MARK - Clean Test
+
+set_up_clean_test
+do_test


### PR DESCRIPTION
- Add `set_up_clean_test` bash script to each workspace with logic for removing BUILD.bazel files and setting up minimal, runnable conditions.
- Update the test runners call perform a test with the code as it is checked-in and to do a clean test.

Closes #69.