### PR TITLE
feat: add support for `target` references and `plugin` targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # To update these lines, execute 
 # `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`
-build --deleted_packages=examples/http_archive_ext_deps,examples/http_archive_ext_deps/Sources/MyDequeModule,examples/http_archive_ext_deps/Sources/PrintStuff,examples/http_archive_ext_deps/Tests/MyDequeModuleTests,examples/pkg_manifest_minimal,examples/pkg_manifest_minimal/Sources/MyExecutable,examples/pkg_manifest_minimal/Sources/MyLibrary,examples/pkg_manifest_minimal/Tests/MyLibraryTests
-query --deleted_packages=examples/http_archive_ext_deps,examples/http_archive_ext_deps/Sources/MyDequeModule,examples/http_archive_ext_deps/Sources/PrintStuff,examples/http_archive_ext_deps/Tests/MyDequeModuleTests,examples/pkg_manifest_minimal,examples/pkg_manifest_minimal/Sources/MyExecutable,examples/pkg_manifest_minimal/Sources/MyLibrary,examples/pkg_manifest_minimal/Tests/MyLibraryTests
+build --deleted_packages=examples/http_archive_ext_deps,examples/http_archive_ext_deps/Sources/MyDequeModule,examples/http_archive_ext_deps/Sources/PrintStuff,examples/http_archive_ext_deps/Tests/MyDequeModuleTests,examples/pkg_manifest_minimal
+query --deleted_packages=examples/http_archive_ext_deps,examples/http_archive_ext_deps/Sources/MyDequeModule,examples/http_archive_ext_deps/Sources/PrintStuff,examples/http_archive_ext_deps/Tests/MyDequeModuleTests,examples/pkg_manifest_minimal
 
 # Import Shared settings
 import %workspace%/shared.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # To update these lines, execute 
 # `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`
-build --deleted_packages=examples/http_archive_ext_deps,examples/http_archive_ext_deps/Sources/MyDequeModule,examples/http_archive_ext_deps/Sources/PrintStuff,examples/http_archive_ext_deps/Tests/MyDequeModuleTests,examples/pkg_manifest_minimal
-query --deleted_packages=examples/http_archive_ext_deps,examples/http_archive_ext_deps/Sources/MyDequeModule,examples/http_archive_ext_deps/Sources/PrintStuff,examples/http_archive_ext_deps/Tests/MyDequeModuleTests,examples/pkg_manifest_minimal
+build --deleted_packages=examples/http_archive_ext_deps,examples/http_archive_ext_deps/Sources/MyDequeModule,examples/http_archive_ext_deps/Sources/PrintStuff,examples/http_archive_ext_deps/Tests/MyDequeModuleTests,examples/pkg_manifest_minimal,examples/pkg_manifest_minimal/Sources/MyExecutable,examples/pkg_manifest_minimal/Sources/MyLibrary,examples/pkg_manifest_minimal/Tests/MyLibraryTests
+query --deleted_packages=examples/http_archive_ext_deps,examples/http_archive_ext_deps/Sources/MyDequeModule,examples/http_archive_ext_deps/Sources/PrintStuff,examples/http_archive_ext_deps/Tests/MyDequeModuleTests,examples/pkg_manifest_minimal,examples/pkg_manifest_minimal/Sources/MyExecutable,examples/pkg_manifest_minimal/Sources/MyLibrary,examples/pkg_manifest_minimal/Tests/MyLibraryTests
 
 # Import Shared settings
 import %workspace%/shared.bazelrc

--- a/examples/pkg_manifest_minimal/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/BUILD.bazel
@@ -45,3 +45,9 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = ["@cgrindel_swift_bazel//swiftpkg:defs"],
 )
+
+alias(
+    name = "swiftformat",
+    # This is the executable product.
+    actual = "@nicklockwood_SwiftFormat//:swiftformat",
+)

--- a/examples/pkg_manifest_minimal/Package.resolved
+++ b/examples/pkg_manifest_minimal/Package.resolved
@@ -17,6 +17,15 @@
         "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
         "version" : "1.4.4"
       }
+    },
+    {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "da637c398c5d08896521b737f2868ddc2e7996ae",
+        "version" : "0.50.6"
+      }
     }
   ],
   "version" : 2

--- a/examples/pkg_manifest_minimal/Package.swift
+++ b/examples/pkg_manifest_minimal/Package.swift
@@ -7,6 +7,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-log", from: "1.4.4"),
+        // Uses old-style executable product referencing a `regular` target.
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "1.4.4"),
     ],
     targets: [
     ]

--- a/examples/pkg_manifest_minimal/Package.swift
+++ b/examples/pkg_manifest_minimal/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-log", from: "1.4.4"),
         // Uses old-style executable product referencing a `regular` target.
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "1.4.4"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.6"),
     ],
     targets: [
     ]

--- a/examples/pkg_manifest_minimal/do_test
+++ b/examples/pkg_manifest_minimal/do_test
@@ -12,7 +12,7 @@ bazel test //...
 
 # Run the executable target
 output="$(bazel run //Sources/MyExecutable)"
-assert_match "Hello, World!" "${output}" 
+[[ "${output}" =~ "Hello, World!" ]] || (echo >&2 "Expected 'Hello, World!'"; exit 1)
 
 # Buid and run the SwiftFormat alias
 bazel run //:swiftformat -- --version

--- a/examples/pkg_manifest_minimal/do_test
+++ b/examples/pkg_manifest_minimal/do_test
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
+
+# Generate Swift external deps and update build files
+bazel run //:tidy
+
+# Ensure that it builds and tests pass
+bazel test //...
+
+# Run the executable target
+output="$(bazel run //Sources/MyExecutable)"
+assert_match "Hello, World!" "${output}" 
+
+# Buid and run the SwiftFormat alias
+bazel run //:swiftformat -- --version

--- a/examples/pkg_manifest_minimal/module_index.json
+++ b/examples/pkg_manifest_minimal/module_index.json
@@ -23,6 +23,9 @@
   "ArgumentParserUnitTests": [
     "@apple_swift_argument_parser//Tests/ArgumentParserUnitTests"
   ],
+  "CommandLineTool": [
+    "@nicklockwood_SwiftFormat//CommandLineTool"
+  ],
   "Generate_Manual": [
     "@apple_swift_argument_parser//Plugins/GenerateManualPlugin:Generate Manual"
   ],
@@ -31,6 +34,15 @@
   ],
   "LoggingTests": [
     "@apple_swift_log//Tests/LoggingTests"
+  ],
+  "SwiftFormat": [
+    "@nicklockwood_SwiftFormat//Sources:SwiftFormat"
+  ],
+  "SwiftFormatPlugin": [
+    "@nicklockwood_SwiftFormat//Plugins/SwiftFormatPlugin"
+  ],
+  "SwiftFormatTests": [
+    "@nicklockwood_SwiftFormat//Tests:SwiftFormatTests"
   ],
   "changelog_authors": [
     "@apple_swift_argument_parser//Tools/changelog-authors"

--- a/examples/pkg_manifest_minimal/set_up_clean_test
+++ b/examples/pkg_manifest_minimal/set_up_clean_test
@@ -7,6 +7,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 # Remove all build files
 find "${script_dir}" -name "BUILD.bazel" -exec rm {} \;
 
+# Remove the SPM build folder
+rm -rf .build
+
 # Replace the swift_deps.bzl with no declarations.
 cat > "${script_dir}/swift_deps.bzl"  <<-EOF
 def swift_dependencies():

--- a/examples/pkg_manifest_minimal/set_up_clean_test
+++ b/examples/pkg_manifest_minimal/set_up_clean_test
@@ -62,4 +62,10 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = ["@cgrindel_swift_bazel//swiftpkg:defs"],
 )
+
+alias(
+    name = "swiftformat",
+    # This is the executable product.
+    actual = "@nicklockwood_SwiftFormat//:swiftformat",
+)
 EOF

--- a/examples/pkg_manifest_minimal/swift_deps.bzl
+++ b/examples/pkg_manifest_minimal/swift_deps.bzl
@@ -16,3 +16,11 @@ def swift_dependencies():
         module_index = "@//:module_index.json",
         remote = "https://github.com/apple/swift-log",
     )
+
+    # version: 0.50.6
+    swift_package(
+        name = "nicklockwood_SwiftFormat",
+        commit = "da637c398c5d08896521b737f2868ddc2e7996ae",
+        module_index = "@//:module_index.json",
+        remote = "https://github.com/nicklockwood/SwiftFormat",
+    )

--- a/examples/pkg_manifest_minimal_test_runner.sh
+++ b/examples/pkg_manifest_minimal_test_runner.sh
@@ -39,18 +39,6 @@ cd "${scratch_dir}"
 # Dump Bazel info
 bazel info
 
-do_test() {
-  # Generate Swift external deps and update build files
-  bazel run //:tidy
-
-  # Ensure that it builds
-  bazel test //...
-
-  # Run the product alias
-  output="$(bazel run //Sources/MyExecutable)"
-  assert_match "Hello, World!" "${output}" 
-}
-
 # MARK - Test As Is
 
 do_test

--- a/gazelle/internal/spdump/target.go
+++ b/gazelle/internal/spdump/target.go
@@ -1,8 +1,6 @@
 package spdump
 
-import (
-	"strings"
-)
+import "encoding/json"
 
 type TargetType int
 
@@ -11,11 +9,15 @@ const (
 	ExecutableTargetType
 	LibraryTargetType
 	TestTargetType
+	PluginTargetType
 )
 
 func (tt *TargetType) UnmarshalJSON(b []byte) error {
-	// The bytes are a raw string (i.e., includes double quotes at front and back). Remove them.
-	ttStr := strings.Trim(string(b), "\"")
+	var ttStr string
+	err := json.Unmarshal(b, &ttStr)
+	if err != nil {
+		return err
+	}
 	switch ttStr {
 	case "executable":
 		*tt = ExecutableTargetType
@@ -23,6 +25,8 @@ func (tt *TargetType) UnmarshalJSON(b []byte) error {
 		*tt = TestTargetType
 	case "library", "regular":
 		*tt = LibraryTargetType
+	case "plugin":
+		*tt = PluginTargetType
 	default:
 		*tt = UnknownTargetType
 	}

--- a/gazelle/internal/spdump/target_dependency.go
+++ b/gazelle/internal/spdump/target_dependency.go
@@ -10,6 +10,7 @@ import (
 type TargetDependency struct {
 	Product *ProductReference
 	ByName  *ByNameReference
+	Target  *TargetReference
 }
 
 func (td *TargetDependency) ImportName() string {
@@ -52,6 +53,7 @@ func (pr *ProductReference) UniqKey() string {
 
 // Reference a target by name
 type ByNameReference struct {
+	// TODO(chuck): Should this be Name? Can it refer to a target or a product?
 	TargetName string
 }
 
@@ -62,6 +64,25 @@ func (bnr *ByNameReference) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if bnr.TargetName, err = jsonutils.StringAtIndex(raw, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+// TargetReference
+
+// Reference a target by name
+type TargetReference struct {
+	TargetName string
+}
+
+func (tr *TargetReference) UnmarshalJSON(b []byte) error {
+	var err error
+	var raw []any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if tr.TargetName, err = jsonutils.StringAtIndex(raw, 0); err != nil {
 		return err
 	}
 	return nil

--- a/gazelle/internal/swiftbin/swift_bin.go
+++ b/gazelle/internal/swiftbin/swift_bin.go
@@ -3,10 +3,7 @@ package swiftbin
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 )
 
 type Executor interface {
@@ -74,32 +71,5 @@ func (sb *SwiftBin) ResolvePackage(dir string) error {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed executing `swift package resolve`, out\n%v: %w", string(out), err)
 	}
-	// DEBUG BEGIN
-	buildDir := filepath.Join(dir, ".build", "checkouts")
-	debugWalkDir(buildDir, false)
-	// DEBUG END
 	return nil
 }
-
-// DEBUG BEGIN
-
-func debugWalkDir(startDir string, showAllFiles bool) {
-	walkFn := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-		if showAllFiles || (info.IsDir()) {
-			shortPath := strings.TrimPrefix(path, startDir)
-			fmt.Println(shortPath)
-		}
-		return nil
-	}
-	fmt.Printf("Walking %s\n", startDir)
-	err := filepath.Walk(startDir, walkFn)
-	if err != nil {
-		fmt.Println(err)
-	}
-}
-
-// DEBUG END

--- a/gazelle/internal/swiftbin/swift_bin.go
+++ b/gazelle/internal/swiftbin/swift_bin.go
@@ -3,7 +3,10 @@ package swiftbin
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 type Executor interface {
@@ -71,5 +74,32 @@ func (sb *SwiftBin) ResolvePackage(dir string) error {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed executing `swift package resolve`, out\n%v: %w", string(out), err)
 	}
+	// DEBUG BEGIN
+	buildDir := filepath.Join(dir, ".build", "checkouts")
+	debugWalkDir(buildDir, false)
+	// DEBUG END
 	return nil
 }
+
+// DEBUG BEGIN
+
+func debugWalkDir(startDir string, showAllFiles bool) {
+	walkFn := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+		if showAllFiles || (info.IsDir()) {
+			shortPath := strings.TrimPrefix(path, startDir)
+			fmt.Println(shortPath)
+		}
+		return nil
+	}
+	fmt.Printf("Walking %s\n", startDir)
+	err := filepath.Walk(startDir, walkFn)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+// DEBUG END

--- a/gazelle/internal/swiftpkg/dependency.go
+++ b/gazelle/internal/swiftpkg/dependency.go
@@ -2,6 +2,8 @@ package swiftpkg
 
 import (
 	"log"
+	"path"
+	"strings"
 
 	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
 )
@@ -35,6 +37,16 @@ func (d *Dependency) URL() string {
 	}
 	log.Fatalf("URL could not be determined.")
 	return ""
+}
+
+func (d *Dependency) SPMCheckoutDirname() string {
+	url := d.URL()
+	base := path.Base(url)
+	ext := path.Ext(base)
+	if ext == "" {
+		return base
+	}
+	return strings.TrimSuffix(base, ext)
 }
 
 // SourceControl

--- a/gazelle/internal/swiftpkg/target.go
+++ b/gazelle/internal/swiftpkg/target.go
@@ -16,6 +16,7 @@ const (
 	ExecutableTargetType
 	LibraryTargetType
 	TestTargetType
+	PluginTargetType
 )
 
 // Targets
@@ -63,10 +64,15 @@ func NewTargetFromManifestInfo(descT *spdesc.Target, dumpT *spdump.Target) (*Tar
 		targetType = LibraryTargetType
 	case spdump.TestTargetType:
 		targetType = TestTargetType
+	case spdump.PluginTargetType:
+		targetType = PluginTargetType
 	default:
 		return nil, fmt.Errorf(
 			"unrecognized spdump.TargetType %v for %s target", dumpT.Type, dumpT.Name)
 	}
+
+	// TODO(chuck): A Swift plugin can have a dependency on an executable target. In this case, we
+	// want to add the target as a data dependency.
 
 	var err error
 	tdeps := make([]*TargetDependency, len(dumpT.Dependencies))

--- a/gazelle/internal/swiftpkg/target_dependency.go
+++ b/gazelle/internal/swiftpkg/target_dependency.go
@@ -9,21 +9,26 @@ import (
 type TargetDependency struct {
 	Product *ProductReference
 	ByName  *ByNameReference
+	Target  *TargetReference
 }
 
 func NewTargetDependencyFromManifestInfo(dumpTD *spdump.TargetDependency) (*TargetDependency, error) {
 	var prodRef *ProductReference
 	var byNameRef *ByNameReference
+	var targetRef *TargetReference
 	if dumpTD.Product != nil {
 		prodRef = NewProductReferenceFromManifestInfo(dumpTD.Product)
 	} else if dumpTD.ByName != nil {
 		byNameRef = NewByNameReferenceFromManifestInfo(dumpTD.ByName)
+	} else if dumpTD.Target != nil {
+		targetRef = NewTargetReferenceFromManifestInfo(dumpTD.Target)
 	} else {
 		return nil, fmt.Errorf("invalid target dependency")
 	}
 	return &TargetDependency{
 		Product: prodRef,
 		ByName:  byNameRef,
+		Target:  targetRef,
 	}, nil
 }
 
@@ -61,11 +66,25 @@ func (pr *ProductReference) UniqKey() string {
 
 // Reference a target by name
 type ByNameReference struct {
+	// TODO(chuck): Should this be Name? Can it refer to a target or a product?
 	TargetName string
 }
 
 func NewByNameReferenceFromManifestInfo(dumpBNR *spdump.ByNameReference) *ByNameReference {
 	return &ByNameReference{
 		TargetName: dumpBNR.TargetName,
+	}
+}
+
+// TargetReference
+
+// Reference a target by name
+type TargetReference struct {
+	TargetName string
+}
+
+func NewTargetReferenceFromManifestInfo(dumpTR *spdump.TargetReference) *TargetReference {
+	return &TargetReference{
+		TargetName: dumpTR.TargetName,
 	}
 }

--- a/gazelle/update_repos.go
+++ b/gazelle/update_repos.go
@@ -69,7 +69,7 @@ func importReposFromPackageManifest(args language.ImportReposArgs) language.Impo
 			pkgDir,
 			swiftPkgBuildDirname,
 			swiftPkgCheckoutsDirname,
-			dep.Identity(),
+			dep.SPMCheckoutDirname(),
 		)
 		if err != nil {
 			result.Error = err

--- a/swiftpkg/internal/pkginfo_target_deps.bzl
+++ b/swiftpkg/internal/pkginfo_target_deps.bzl
@@ -21,12 +21,22 @@ def make_pkginfo_target_deps(bazel_labels):
         if target_dep.by_name:
             label = module_indexes.find_with_ctx(
                 pkg_ctx.module_index_ctx,
-                target_dep.by_name.target_name,
+                target_dep.by_name.name,
             )
             if label == None:
                 fail("""\
 Unable to resolve by_name target dependency for {module_name}.
 """.format(module_name = target_dep.by_name.target_name))
+
+        elif target_dep.target:
+            label = module_indexes.find_with_ctx(
+                pkg_ctx.module_index_ctx,
+                target_dep.target.target_name,
+            )
+            if label == None:
+                fail("""\
+Unable to resolve target reference target dependency for {module_name}.
+""".format(module_name = target_dep.target.target_name))
 
         elif target_dep.product:
             prod_ref = target_dep.product

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -427,7 +427,7 @@ def _new_target_dependency(by_name = None, product = None, target = None):
 
     Args:
         by_name: A `struct` as returned by
-            `pkginfos.new_target_reference()`.
+            `pkginfos.new_by_name_reference()`.
         product: A `struct` as returned by
             `pkginfos.new_product_reference()`.
         target: A `struct` as returned by

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -123,7 +123,7 @@ def _new_product_from_desc_json_map(prd_map):
 
 def _new_target_dependency_from_dump_json_map(dep_map):
     by_name_list = dep_map.get("byName")
-    by_name = _new_target_reference(by_name_list[0]) if by_name_list else None
+    by_name = _new_by_name_reference(by_name_list[0]) if by_name_list else None
 
     product = None
     product_list = dep_map.get("product")
@@ -133,9 +133,13 @@ def _new_target_dependency_from_dump_json_map(dep_map):
             dep_identity = product_list[1],
         )
 
+    target_list = dep_map.get("target")
+    target = _new_target_reference(target_list[0]) if target_list else None
+
     return _new_target_dependency(
         by_name = by_name,
         product = product,
+        target = target,
     )
 
 def _new_target_from_json_maps(dump_map, desc_map):
@@ -392,11 +396,24 @@ def _new_product_reference(product_name, dep_identity):
         dep_identity = dep_identity,
     )
 
+def _new_by_name_reference(name):
+    """Creates a by-name reference.
+
+    Args:
+        name: The name of a target or product (`string`).
+
+    Returns:
+        A `struct` representing a by-name reference.
+    """
+    return struct(
+        name = name,
+    )
+
 def _new_target_reference(target_name):
     """Creates a target reference.
 
     Args:
-        target_name: The name of the target (`string`).
+        target_name: The name of a target (`string`).
 
     Returns:
         A `struct` representing a target reference.
@@ -405,7 +422,7 @@ def _new_target_reference(target_name):
         target_name = target_name,
     )
 
-def _new_target_dependency(by_name = None, product = None):
+def _new_target_dependency(by_name = None, product = None, target = None):
     """Creates a target dependency.
 
     Args:
@@ -413,17 +430,20 @@ def _new_target_dependency(by_name = None, product = None):
             `pkginfos.new_target_reference()`.
         product: A `struct` as returned by
             `pkginfos.new_product_reference()`.
+        target: A `struct` as returned by
+            `pkginfos.new_target_reference()`.
 
     Returns:
         A `struct` representing a target dependency.
     """
-    if by_name == None and product == None:
+    if by_name == None and product == None and target == None:
         fail("""\
-A target dependency must have one of the following: `by_name` or a `product`.\
+A target dependency must have one of the following: `by_name`, `product`, `target`.\
 """)
     return struct(
         by_name = by_name,
         product = product,
+        target = target,
     )
 
 def _new_target(name, type, c99name, module_type, path, sources, dependencies):
@@ -511,6 +531,7 @@ pkginfos = struct(
     new_product = _new_product,
     new_product_type = _new_product_type,
     new_product_reference = _new_product_reference,
+    new_by_name_reference = _new_by_name_reference,
     new_target_reference = _new_target_reference,
     new_target_dependency = _new_target_dependency,
     new_target = _new_target,

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -11,10 +11,6 @@ load(":pkginfos.bzl", "module_types", "target_types")
 # MARK: - Target Entry Point
 
 def _new_for_target(pkg_ctx, target):
-    # DEBUG BEGIN
-    print("*** CHUCK new_for_target target: ", target)
-
-    # DEBUG END
     if target.module_type == module_types.clang:
         return _clang_target_build_file(target)
     elif target.module_type == module_types.swift:

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -56,6 +56,9 @@ def _swift_library_from_target(target, deps):
         kind = swift_kinds.library,
         name = target.name,
         attrs = {
+            # SPM directive instructing the code to build as if a Swift package.
+            # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
+            "defines": ["SWIFT_PACKAGE"],
             "deps": deps,
             "module_name": target.c99name,
             "srcs": target.sources,
@@ -68,6 +71,9 @@ def _swift_binary_from_target(target, deps):
         kind = swift_kinds.binary,
         name = target.name,
         attrs = {
+            # SPM directive instructing the code to build as if a Swift package.
+            # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
+            "defines": ["SWIFT_PACKAGE"],
             "deps": deps,
             "module_name": target.c99name,
             "srcs": target.sources,
@@ -80,6 +86,9 @@ def _swift_test_from_target(target, deps):
         kind = swift_kinds.test,
         name = target.name,
         attrs = {
+            # SPM directive instructing the code to build as if a Swift package.
+            # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
+            "defines": ["SWIFT_PACKAGE"],
             "deps": deps,
             "module_name": target.c99name,
             "srcs": target.sources,

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -11,6 +11,10 @@ load(":pkginfos.bzl", "module_types", "target_types")
 # MARK: - Target Entry Point
 
 def _new_for_target(pkg_ctx, target):
+    # DEBUG BEGIN
+    print("*** CHUCK new_for_target target: ", target)
+
+    # DEBUG END
     if target.module_type == module_types.clang:
         return _clang_target_build_file(target)
     elif target.module_type == module_types.swift:
@@ -114,6 +118,8 @@ def _new_for_product(pkg_info, product, repo_name):
         return _executable_product_build_file(pkg_info, product, repo_name)
     elif prod_type.is_library:
         return _library_product_build_file(pkg_info, product, repo_name)
+
+    # TODO(chuck): Check for plugin product
     return None
 
 def _executable_product_build_file(pkg_info, product, repo_name):

--- a/swiftpkg/tests/pkginfo_target_deps_tests.bzl
+++ b/swiftpkg/tests/pkginfo_target_deps_tests.bzl
@@ -26,7 +26,7 @@ _external_dep = pkginfos.new_dependency(
         ],
     ),
 )
-_by_name = pkginfos.new_target_reference("Foo")
+_by_name = pkginfos.new_by_name_reference("Foo")
 _product_ref = pkginfos.new_product_reference(
     product_name = "AwesomePackage",
     dep_identity = _external_dep.identity,

--- a/swiftpkg/tests/pkginfos_tests.bzl
+++ b/swiftpkg/tests/pkginfos_tests.bzl
@@ -68,8 +68,8 @@ def _get_test(ctx):
                 ],
                 dependencies = [
                     pkginfos.new_target_dependency(
-                        by_name = pkginfos.new_target_reference(
-                            target_name = "MySwiftPackage",
+                        by_name = pkginfos.new_by_name_reference(
+                            name = "MySwiftPackage",
                         ),
                     ),
                 ],

--- a/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
@@ -64,7 +64,7 @@ _pkg_info = pkginfos.new(
             ],
             dependencies = [
                 pkginfos.new_target_dependency(
-                    by_name = pkginfos.new_target_reference(
+                    by_name = pkginfos.new_by_name_reference(
                         "SwiftLintFramework",
                     ),
                 ),
@@ -92,7 +92,7 @@ _pkg_info = pkginfos.new(
             ],
             dependencies = [
                 pkginfos.new_target_dependency(
-                    by_name = pkginfos.new_target_reference(
+                    by_name = pkginfos.new_by_name_reference(
                         "SwiftLintFramework",
                     ),
                 ),

--- a/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
@@ -129,6 +129,7 @@ def _swift_library_target_test(ctx):
                 kind = swift_kinds.library,
                 name = "SwiftLintFramework",
                 attrs = {
+                    "defines": ["SWIFT_PACKAGE"],
                     "deps": [],
                     "module_name": "SwiftLintFramework",
                     "srcs": [
@@ -160,6 +161,7 @@ def _swift_library_target_for_binary_test(ctx):
                 kind = swift_kinds.library,
                 name = "swiftlint",
                 attrs = {
+                    "defines": ["SWIFT_PACKAGE"],
                     "deps": [
                         "@realm_swiftlint//Source/SwiftLintFramework",
                     ],
@@ -191,6 +193,7 @@ def _swift_test_target_test(ctx):
                 kind = swift_kinds.test,
                 name = "SwiftLintFrameworkTests",
                 attrs = {
+                    "defines": ["SWIFT_PACKAGE"],
                     "deps": [
                         "@realm_swiftlint//Source/SwiftLintFramework",
                     ],


### PR DESCRIPTION
- Add support for `target` reference. This is different from `byName`.
  - Renamed `pkginfos.new_target_reference` to `pkginfos.new_by_name_reference`.
- Add SwiftFormat to the `pkg_manifest_minimal` example.
- Include `SWIFT_PACKAGE` directive when defining targets from `swift_package`.

Related to #52.
Related to #46.