### PR TITLE
fix: ensure `deps` are properly updated if a dependency disappears from the target

### DIFF
--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     srcs = [
         "config.go",
         "generate.go",
+        "kinds.go",
         "lang.go",
         "resolve.go",
         "update_repos.go",

--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "@bazel_gazelle//repo:go_default_library",
         "@bazel_gazelle//resolve:go_default_library",
         "@bazel_gazelle//rule:go_default_library",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -3,13 +3,13 @@ package gazelle
 import (
 	"log"
 	"path/filepath"
+	"sort"
 
 	"github.com/bazelbuild/bazel-gazelle/language"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/stringslices"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftcfg"
-	"golang.org/x/exp/slices"
 )
 
 func (l *swiftLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
@@ -51,7 +51,7 @@ func genRulesFromSrcFiles(sc *swiftcfg.SwiftConfig, args language.GenerateArgs) 
 
 	// Retrieve any Swift files that have already been found
 	srcs := append(swiftFiles, sc.ModuleFilesCollector.GetModuleFiles(moduleDir)...)
-	slices.Sort(srcs)
+	sort.Strings(srcs)
 
 	// Generate the rules and imports
 	result.Gen = swift.RulesFromSrcs(args, srcs)

--- a/gazelle/internal/pathdistance/BUILD.bazel
+++ b/gazelle/internal/pathdistance/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     srcs = ["pathdistance.go"],
     importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/pathdistance",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_exp//slices"],
+    deps = ["//gazelle/internal/stringslices"],
 )
 
 go_test(

--- a/gazelle/internal/pathdistance/pathdistance.go
+++ b/gazelle/internal/pathdistance/pathdistance.go
@@ -3,7 +3,7 @@ package pathdistance
 import (
 	"path/filepath"
 
-	"golang.org/x/exp/slices"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/stringslices"
 )
 
 func PathAt(path string, distance int) string {
@@ -23,7 +23,7 @@ func doDistanceFrom(values []string, path string, distance int) int {
 		return -1
 	}
 	basename := filepath.Base(path)
-	if slices.Contains(values, basename) {
+	if stringslices.Contains(values, basename) {
 		return distance
 	}
 	parent := parentDir(path)

--- a/gazelle/internal/stringslices/contains.go
+++ b/gazelle/internal/stringslices/contains.go
@@ -1,10 +1,24 @@
 package stringslices
 
+import (
+	"sort"
+)
+
 func Contains(values []string, target string) bool {
 	for _, v := range values {
 		if v == target {
 			return true
 		}
+	}
+	return false
+}
+
+// Performs binary search for the target. The values must be sorted in ascending order.
+func SortedContains(values []string, target string) bool {
+	idx := sort.SearchStrings(values, target)
+	valuesLen := len(values)
+	if idx < valuesLen {
+		return values[idx] == target
 	}
 	return false
 }

--- a/gazelle/internal/stringslices/contains_test.go
+++ b/gazelle/internal/stringslices/contains_test.go
@@ -13,3 +13,12 @@ func TestContains(t *testing.T) {
 	assert.True(t, stringslices.Contains(values, "Bar"))
 	assert.False(t, stringslices.Contains(values, "Chicken"))
 }
+
+func TestSortedContains(t *testing.T) {
+	values := []string{"apple", "mango", "zebra"}
+	assert.True(t, stringslices.SortedContains(values, "apple"))
+	assert.True(t, stringslices.SortedContains(values, "mango"))
+	assert.True(t, stringslices.SortedContains(values, "zebra"))
+	assert.False(t, stringslices.SortedContains(values, "doesNotExist"))
+	assert.False(t, stringslices.SortedContains(values, "zoo"))
+}

--- a/gazelle/kinds.go
+++ b/gazelle/kinds.go
@@ -20,6 +20,8 @@ var kinds = map[string]rule.KindInfo{
 			"srcs":          true,
 			"swiftc_inputs": true,
 		},
+		// This ensures that the deps attribute is updated properly if a dependency disappears.
+		ResolveAttrs: map[string]bool{"deps": true},
 	},
 	swift.LibraryRuleKind: rule.KindInfo{
 		MatchAttrs: []string{"module_name"},
@@ -39,6 +41,8 @@ var kinds = map[string]rule.KindInfo{
 			"srcs":                  true,
 			"swiftc_inputs":         true,
 		},
+		// This ensures that the deps attribute is updated properly if a dependency disappears.
+		ResolveAttrs: map[string]bool{"deps": true},
 	},
 	swift.TestRuleKind: rule.KindInfo{
 		MatchAny: true,
@@ -55,6 +59,8 @@ var kinds = map[string]rule.KindInfo{
 			"srcs":          true,
 			"swiftc_inputs": true,
 		},
+		// This ensures that the deps attribute is updated properly if a dependency disappears.
+		ResolveAttrs: map[string]bool{"deps": true},
 	},
 }
 

--- a/gazelle/kinds.go
+++ b/gazelle/kinds.go
@@ -1,0 +1,63 @@
+package gazelle
+
+import (
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
+)
+
+var kinds = map[string]rule.KindInfo{
+	swift.BinaryRuleKind: rule.KindInfo{
+		MatchAny: true,
+		NonEmptyAttrs: map[string]bool{
+			"srcs": true,
+			"deps": true,
+		},
+		MergeableAttrs: map[string]bool{
+			"copts":         true,
+			"defines":       true,
+			"linkopts":      true,
+			"malloc":        true,
+			"srcs":          true,
+			"swiftc_inputs": true,
+		},
+	},
+	swift.LibraryRuleKind: rule.KindInfo{
+		MatchAttrs: []string{"module_name"},
+		NonEmptyAttrs: map[string]bool{
+			"srcs":         true,
+			"deps":         true,
+			"private_deps": true,
+		},
+		MergeableAttrs: map[string]bool{
+			"alwayslink":            true,
+			"copts":                 true,
+			"defines":               true,
+			"generated_header_name": true,
+			"generates_header":      true,
+			"linkopts":              true,
+			"linkstatic":            true,
+			"srcs":                  true,
+			"swiftc_inputs":         true,
+		},
+	},
+	swift.TestRuleKind: rule.KindInfo{
+		MatchAny: true,
+		NonEmptyAttrs: map[string]bool{
+			"srcs": true,
+			"deps": true,
+		},
+		MergeableAttrs: map[string]bool{
+			"copts":         true,
+			"defines":       true,
+			"env":           true,
+			"linkopts":      true,
+			"malloc":        true,
+			"srcs":          true,
+			"swiftc_inputs": true,
+		},
+	},
+}
+
+func (*swiftLang) Kinds() map[string]rule.KindInfo {
+	return kinds
+}

--- a/gazelle/lang.go
+++ b/gazelle/lang.go
@@ -8,16 +8,6 @@ import (
 
 const swiftLangName = "swift"
 
-var kindShared = rule.KindInfo{
-	NonEmptyAttrs:  map[string]bool{"srcs": true, "deps": true},
-	MergeableAttrs: map[string]bool{"srcs": true},
-}
-
-var kinds = map[string]rule.KindInfo{
-	swift.LibraryRuleKind: kindShared,
-	swift.BinaryRuleKind:  kindShared,
-	swift.TestRuleKind:    kindShared,
-}
 
 var loads = []rule.LoadInfo{
 	{
@@ -45,10 +35,6 @@ func NewLanguage() language.Language {
 }
 
 func (*swiftLang) Name() string { return swiftLangName }
-
-func (*swiftLang) Kinds() map[string]rule.KindInfo {
-	return kinds
-}
 
 func (*swiftLang) Loads() []rule.LoadInfo {
 	return loads

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -2,6 +2,7 @@ package gazelle
 
 import (
 	"log"
+	"sort"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
@@ -59,6 +60,7 @@ func (l *swiftLang) Resolve(
 		}
 	}
 
+	sort.Strings(deps)
 	if len(deps) > 0 {
 		r.SetAttr("deps", deps)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/bazelbuild/bazel-gazelle v0.28.0
 	github.com/bazelbuild/buildtools v0.0.0-20221110131218-762712d8ce3f
 	github.com/stretchr/testify v1.8.1
-	golang.org/x/exp v0.0.0-20221215174704-0915cd710c24
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 go.starlark.net v0.0.0-20210223155950-e043a3d3c984/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20221215174704-0915cd710c24 h1:6w3iSY8IIkp5OQtbYj8NeuKG1jS9d+kYaubXqsoOiQ8=
-golang.org/x/exp v0.0.0-20221215174704-0915cd710c24/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -251,8 +251,8 @@ def swift_bazel_go_dependencies():
         name = "org_golang_x_exp",
         build_external = "external",
         importpath = "golang.org/x/exp",
-        sum = "h1:6w3iSY8IIkp5OQtbYj8NeuKG1jS9d+kYaubXqsoOiQ8=",
-        version = "v0.0.0-20221215174704-0915cd710c24",
+        sum = "h1:c2HOrn5iMezYjSlGPncknSEr/8x5LELb/ilJbXi9DEA=",
+        version = "v0.0.0-20190121172915-509febef88a4",
     )
     go_repository(
         name = "org_golang_x_lint",


### PR DESCRIPTION
- Ensure that obsolete Swift targets are removed if no srcs match.
- Add `deps` to list of attributes to be merged after dependency resolution.
- Remove `golang.org/x/exp/slices`.

Closes #70.