### PR TITLE
chore: create a single Bazel build file for each external Swift package

### DIFF
--- a/examples/http_archive_ext_deps/WORKSPACE
+++ b/examples/http_archive_ext_deps/WORKSPACE
@@ -81,7 +81,30 @@ swift_library(
     url = "https://github.com/apple/swift-collections/archive/refs/tags/1.0.2.tar.gz",
 )
 
-http_archive(
+# TODO(chuck): Revert me before merge!
+
+# http_archive(
+#     name = "com_github_apple_swift_argument_parser",
+#     build_file_content = """\
+# load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+# swift_library(
+#     name = "ArgumentParser",
+#     srcs = glob(["Sources/ArgumentParser/**/*.swift"]),
+#     visibility = ["//visibility:public"],
+#     deps = [":ArgumentParserToolInfo"],
+# )
+# swift_library(
+#     name = "ArgumentParserToolInfo",
+#     srcs = glob(["Sources/ArgumentParserToolInfo/**/*.swift"]),
+#     visibility = ["//visibility:public"],
+# )
+# """,
+#     sha256 = "f2c3a7f20e6dede610e7bd7e6cc9e352df54070769bc5b7f5d4bb2868e3c10ae",
+#     strip_prefix = "swift-argument-parser-1.2.0",
+#     url = "https://github.com/apple/swift-argument-parser/archive/1.2.0.tar.gz",
+# )
+
+new_local_repository(
     name = "com_github_apple_swift_argument_parser",
     build_file_content = """\
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
@@ -97,7 +120,5 @@ swift_library(
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "f2c3a7f20e6dede610e7bd7e6cc9e352df54070769bc5b7f5d4bb2868e3c10ae",
-    strip_prefix = "swift-argument-parser-1.2.0",
-    url = "https://github.com/apple/swift-argument-parser/archive/1.2.0.tar.gz",
+    path = "/Users/chuck/code/apple/swift-argument-parser",
 )

--- a/examples/http_archive_ext_deps/WORKSPACE
+++ b/examples/http_archive_ext_deps/WORKSPACE
@@ -81,30 +81,7 @@ swift_library(
     url = "https://github.com/apple/swift-collections/archive/refs/tags/1.0.2.tar.gz",
 )
 
-# TODO(chuck): Revert me before merge!
-
-# http_archive(
-#     name = "com_github_apple_swift_argument_parser",
-#     build_file_content = """\
-# load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-# swift_library(
-#     name = "ArgumentParser",
-#     srcs = glob(["Sources/ArgumentParser/**/*.swift"]),
-#     visibility = ["//visibility:public"],
-#     deps = [":ArgumentParserToolInfo"],
-# )
-# swift_library(
-#     name = "ArgumentParserToolInfo",
-#     srcs = glob(["Sources/ArgumentParserToolInfo/**/*.swift"]),
-#     visibility = ["//visibility:public"],
-# )
-# """,
-#     sha256 = "f2c3a7f20e6dede610e7bd7e6cc9e352df54070769bc5b7f5d4bb2868e3c10ae",
-#     strip_prefix = "swift-argument-parser-1.2.0",
-#     url = "https://github.com/apple/swift-argument-parser/archive/1.2.0.tar.gz",
-# )
-
-new_local_repository(
+http_archive(
     name = "com_github_apple_swift_argument_parser",
     build_file_content = """\
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
@@ -120,5 +97,7 @@ swift_library(
     visibility = ["//visibility:public"],
 )
 """,
-    path = "/Users/chuck/code/apple/swift-argument-parser",
+    sha256 = "f2c3a7f20e6dede610e7bd7e6cc9e352df54070769bc5b7f5d4bb2868e3c10ae",
+    strip_prefix = "swift-argument-parser-1.2.0",
+    url = "https://github.com/apple/swift-argument-parser/archive/1.2.0.tar.gz",
 )

--- a/examples/pkg_manifest_minimal/Sources/MyExecutable/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/Sources/MyExecutable/BUILD.bazel
@@ -8,6 +8,6 @@ swift_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//Sources/MyLibrary",
-        "@apple_swift_argument_parser//Sources/ArgumentParser",
+        "@apple_swift_argument_parser//:Sources_ArgumentParser",
     ],
 )

--- a/examples/pkg_manifest_minimal/module_index.json
+++ b/examples/pkg_manifest_minimal/module_index.json
@@ -1,65 +1,65 @@
 {
   "ArgumentParser": [
-    "@apple_swift_argument_parser//Sources/ArgumentParser"
+    "@apple_swift_argument_parser//:Sources_ArgumentParser"
   ],
   "ArgumentParserEndToEndTests": [
-    "@apple_swift_argument_parser//Tests/ArgumentParserEndToEndTests"
+    "@apple_swift_argument_parser//:Tests_ArgumentParserEndToEndTests"
   ],
   "ArgumentParserExampleTests": [
-    "@apple_swift_argument_parser//Tests/ArgumentParserExampleTests"
+    "@apple_swift_argument_parser//:Tests_ArgumentParserExampleTests"
   ],
   "ArgumentParserGenerateManualTests": [
-    "@apple_swift_argument_parser//Tests/ArgumentParserGenerateManualTests"
+    "@apple_swift_argument_parser//:Tests_ArgumentParserGenerateManualTests"
   ],
   "ArgumentParserPackageManagerTests": [
-    "@apple_swift_argument_parser//Tests/ArgumentParserPackageManagerTests"
+    "@apple_swift_argument_parser//:Tests_ArgumentParserPackageManagerTests"
   ],
   "ArgumentParserTestHelpers": [
-    "@apple_swift_argument_parser//Sources/ArgumentParserTestHelpers"
+    "@apple_swift_argument_parser//:Sources_ArgumentParserTestHelpers"
   ],
   "ArgumentParserToolInfo": [
-    "@apple_swift_argument_parser//Sources/ArgumentParserToolInfo"
+    "@apple_swift_argument_parser//:Sources_ArgumentParserToolInfo"
   ],
   "ArgumentParserUnitTests": [
-    "@apple_swift_argument_parser//Tests/ArgumentParserUnitTests"
+    "@apple_swift_argument_parser//:Tests_ArgumentParserUnitTests"
   ],
   "CommandLineTool": [
-    "@nicklockwood_SwiftFormat//CommandLineTool"
+    "@nicklockwood_SwiftFormat//:CommandLineTool"
   ],
   "Generate_Manual": [
-    "@apple_swift_argument_parser//Plugins/GenerateManualPlugin:Generate Manual"
+    "@apple_swift_argument_parser//:Plugins_GenerateManualPlugin_Generate Manual"
   ],
   "Logging": [
-    "@apple_swift_log//Sources/Logging"
+    "@apple_swift_log//:Sources_Logging"
   ],
   "LoggingTests": [
-    "@apple_swift_log//Tests/LoggingTests"
+    "@apple_swift_log//:Tests_LoggingTests"
   ],
   "SwiftFormat": [
-    "@nicklockwood_SwiftFormat//Sources:SwiftFormat"
+    "@nicklockwood_SwiftFormat//:Sources_SwiftFormat"
   ],
   "SwiftFormatPlugin": [
-    "@nicklockwood_SwiftFormat//Plugins/SwiftFormatPlugin"
+    "@nicklockwood_SwiftFormat//:Plugins_SwiftFormatPlugin"
   ],
   "SwiftFormatTests": [
-    "@nicklockwood_SwiftFormat//Tests:SwiftFormatTests"
+    "@nicklockwood_SwiftFormat//:Tests_SwiftFormatTests"
   ],
   "changelog_authors": [
-    "@apple_swift_argument_parser//Tools/changelog-authors"
+    "@apple_swift_argument_parser//:Tools_changelog-authors"
   ],
   "count_lines": [
-    "@apple_swift_argument_parser//Examples/count-lines"
+    "@apple_swift_argument_parser//:Examples_count-lines"
   ],
   "generate_manual": [
-    "@apple_swift_argument_parser//Tools/generate-manual"
+    "@apple_swift_argument_parser//:Tools_generate-manual"
   ],
   "math": [
-    "@apple_swift_argument_parser//Examples/math"
+    "@apple_swift_argument_parser//:Examples_math"
   ],
   "repeat": [
-    "@apple_swift_argument_parser//Examples/repeat"
+    "@apple_swift_argument_parser//:Examples_repeat"
   ],
   "roll": [
-    "@apple_swift_argument_parser//Examples/roll"
+    "@apple_swift_argument_parser//:Examples_roll"
   ]
 }

--- a/gazelle/internal/swift/bazel_label.go
+++ b/gazelle/internal/swift/bazel_label.go
@@ -1,10 +1,21 @@
 package swift
 
 import (
+	"path"
+	"strings"
+
 	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg"
 )
 
 func BazelLabelFromTarget(repoName string, target *swiftpkg.Target) label.Label {
-	return label.New(repoName, target.Path, target.Name)
+	var name string
+	basename := path.Base(target.Path)
+	if basename == target.Name {
+		name = target.Path
+	} else {
+		name = path.Join(target.Path, target.Name)
+	}
+	name = strings.ReplaceAll(name, "/", "_")
+	return label.New(repoName, "", name)
 }

--- a/gazelle/internal/swift/bazel_label_test.go
+++ b/gazelle/internal/swift/bazel_label_test.go
@@ -15,7 +15,7 @@ func TestBazelLabelFromTarget(t *testing.T) {
 		Path: "Sources/Foo",
 	}
 	actual := swift.BazelLabelFromTarget("example_cool_repo", target)
-	expected, err := label.Parse("@example_cool_repo//Sources/Foo")
+	expected, err := label.Parse("@example_cool_repo//:Sources_Foo")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }

--- a/swiftpkg/internal/pkginfo_targets.bzl
+++ b/swiftpkg/internal/pkginfo_targets.bzl
@@ -25,12 +25,28 @@ def _get(targets, name, fail_if_not_found = True):
     return None
 
 def _srcs(target):
+    """Returns the sources formatted for inclusion in a Bazel target's `srcs` attribute.
+
+    Args:
+        target: A `struct` as returned from `pkginfos.new_target`.
+
+    Returns:
+        A `list` of `string` values representing the path to source files for the target.
+    """
     return [
         paths.join(target.path, src)
         for src in target.sources
     ]
 
 def _bazel_label_name(target):
+    """Returns the name of the Bazel label for the specified target.
+
+    Args:
+        target: A `struct` as returned from `pkginfos.new_target`.
+
+    Returns:
+        A `string` representing the Bazel label name.
+    """
     basename = paths.basename(target.path)
     if basename == target.name:
         name = target.path

--- a/swiftpkg/internal/pkginfo_targets.bzl
+++ b/swiftpkg/internal/pkginfo_targets.bzl
@@ -33,8 +33,10 @@ def _srcs(target):
 def _bazel_label_name(target):
     basename = paths.basename(target.path)
     if basename == target.name:
-        return target.path
-    return paths.join(target.path, target.name)
+        name = target.path
+    else:
+        name = paths.join(target.path, target.name)
+    return name.replace("/", "_")
 
 def make_pkginfo_targets(bazel_labels):
     """Create a `pkginfo_targets` module.

--- a/swiftpkg/internal/swift_package.bzl
+++ b/swiftpkg/internal/swift_package.bzl
@@ -1,7 +1,6 @@
 """Implementation for `swift_package`."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@bazel_tools//tools/build_defs/repo:git_worker.bzl", "git_repo")
 load(
@@ -83,21 +82,20 @@ def _gen_build_files(repository_ctx, pkg_info):
         ),
     )
 
-    # Create build files for each Swift package target in their corresponding
-    # target path.
+    # Create Bazel declarations for the Swift package targets
+    bld_files = []
     for target in pkg_info.targets:
         bld_file = swiftpkg_build_files.new_for_target(pkg_ctx, target)
         if bld_file == None:
             continue
-        build_files.write(
-            repository_ctx,
-            bld_file,
-            paths.join(pkg_info.path, target.path),
-        )
+        bld_files.append(bld_file)
 
-    # Create a build file at the root with all of the products
-    bld_file = swiftpkg_build_files.new_for_products(pkg_info, repo_name)
-    build_files.write(repository_ctx, bld_file, pkg_info.path)
+    # Create Bazel declarations for the targets
+    bld_files.append(swiftpkg_build_files.new_for_products(pkg_info, repo_name))
+
+    # Write the build file
+    root_bld_file = build_files.merge(*bld_files)
+    build_files.write(repository_ctx, root_bld_file, pkg_info.path)
 
 def _swift_package_impl(repository_ctx):
     directory = str(repository_ctx.path("."))

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -29,6 +29,13 @@ def _swift_target_build_file(pkg_ctx, target):
         for td in target.dependencies
     ]
 
+    # # DEBUG BEGIN
+    # print("*** CHUCK _swift_target_build_file target: ", target)
+    # print("*** CHUCK _swift_target_build_file deps: ")
+    # for idx, item in enumerate(deps):
+    #     print("*** CHUCK", idx, ":", item)
+    # # DEBUG END
+
     # GH046: Support plugins.
     if lists.contains([target_types.library, target_types.regular], target.type):
         load_stmts = [swift_library_load_stmt]
@@ -50,14 +57,14 @@ def _swift_target_build_file(pkg_ctx, target):
 def _swift_library_from_target(target, deps):
     return build_decls.new(
         kind = swift_kinds.library,
-        name = target.name,
+        name = pkginfo_targets.bazel_label_name(target),
         attrs = {
             # SPM directive instructing the code to build as if a Swift package.
             # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
             "defines": ["SWIFT_PACKAGE"],
             "deps": deps,
             "module_name": target.c99name,
-            "srcs": target.sources,
+            "srcs": pkginfo_targets.srcs(target),
             "visibility": ["//visibility:public"],
         },
     )
@@ -65,14 +72,14 @@ def _swift_library_from_target(target, deps):
 def _swift_binary_from_target(target, deps):
     return build_decls.new(
         kind = swift_kinds.binary,
-        name = target.name,
+        name = pkginfo_targets.bazel_label_name(target),
         attrs = {
             # SPM directive instructing the code to build as if a Swift package.
             # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
             "defines": ["SWIFT_PACKAGE"],
             "deps": deps,
             "module_name": target.c99name,
-            "srcs": target.sources,
+            "srcs": pkginfo_targets.srcs(target),
             "visibility": ["//visibility:public"],
         },
     )
@@ -80,14 +87,14 @@ def _swift_binary_from_target(target, deps):
 def _swift_test_from_target(target, deps):
     return build_decls.new(
         kind = swift_kinds.test,
-        name = target.name,
+        name = pkginfo_targets.bazel_label_name(target),
         attrs = {
             # SPM directive instructing the code to build as if a Swift package.
             # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
             "defines": ["SWIFT_PACKAGE"],
             "deps": deps,
             "module_name": target.c99name,
-            "srcs": target.sources,
+            "srcs": pkginfo_targets.srcs(target),
             "visibility": ["//visibility:public"],
         },
     )

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -28,17 +28,26 @@ def _swift_target_build_file(pkg_ctx, target):
         pkginfo_target_deps.bazel_label(pkg_ctx, td)
         for td in target.dependencies
     ]
+    attrs = {
+        # SPM directive instructing the code to build as if a Swift package.
+        # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
+        "defines": ["SWIFT_PACKAGE"],
+        "deps": deps,
+        "module_name": target.c99name,
+        "srcs": pkginfo_targets.srcs(target),
+        "visibility": ["//visibility:public"],
+    }
 
     # GH046: Support plugins.
     if lists.contains([target_types.library, target_types.regular], target.type):
         load_stmts = [swift_library_load_stmt]
-        decls = [_swift_library_from_target(target, deps)]
+        decls = [_swift_library_from_target(target, attrs)]
     elif target.type == target_types.executable:
         load_stmts = [swift_binary_load_stmt]
-        decls = [_swift_binary_from_target(target, deps)]
+        decls = [_swift_binary_from_target(target, attrs)]
     elif target.type == target_types.test:
         load_stmts = [swift_test_load_stmt]
-        decls = [_swift_test_from_target(target, deps)]
+        decls = [_swift_test_from_target(target, attrs)]
     else:
         fail("Unrecognized target type for a Swift target. type:", target.type)
 
@@ -47,49 +56,25 @@ def _swift_target_build_file(pkg_ctx, target):
         decls = decls,
     )
 
-def _swift_library_from_target(target, deps):
+def _swift_library_from_target(target, attrs):
     return build_decls.new(
         kind = swift_kinds.library,
         name = pkginfo_targets.bazel_label_name(target),
-        attrs = {
-            # SPM directive instructing the code to build as if a Swift package.
-            # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
-            "defines": ["SWIFT_PACKAGE"],
-            "deps": deps,
-            "module_name": target.c99name,
-            "srcs": pkginfo_targets.srcs(target),
-            "visibility": ["//visibility:public"],
-        },
+        attrs = attrs,
     )
 
-def _swift_binary_from_target(target, deps):
+def _swift_binary_from_target(target, attrs):
     return build_decls.new(
         kind = swift_kinds.binary,
         name = pkginfo_targets.bazel_label_name(target),
-        attrs = {
-            # SPM directive instructing the code to build as if a Swift package.
-            # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
-            "defines": ["SWIFT_PACKAGE"],
-            "deps": deps,
-            "module_name": target.c99name,
-            "srcs": pkginfo_targets.srcs(target),
-            "visibility": ["//visibility:public"],
-        },
+        attrs = attrs,
     )
 
-def _swift_test_from_target(target, deps):
+def _swift_test_from_target(target, attrs):
     return build_decls.new(
         kind = swift_kinds.test,
         name = pkginfo_targets.bazel_label_name(target),
-        attrs = {
-            # SPM directive instructing the code to build as if a Swift package.
-            # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
-            "defines": ["SWIFT_PACKAGE"],
-            "deps": deps,
-            "module_name": target.c99name,
-            "srcs": pkginfo_targets.srcs(target),
-            "visibility": ["//visibility:public"],
-        },
+        attrs = attrs,
     )
 
 # MARK: - Clang Targets

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -29,13 +29,6 @@ def _swift_target_build_file(pkg_ctx, target):
         for td in target.dependencies
     ]
 
-    # # DEBUG BEGIN
-    # print("*** CHUCK _swift_target_build_file target: ", target)
-    # print("*** CHUCK _swift_target_build_file deps: ")
-    # for idx, item in enumerate(deps):
-    #     print("*** CHUCK", idx, ":", item)
-    # # DEBUG END
-
     # GH046: Support plugins.
     if lists.contains([target_types.library, target_types.regular], target.type):
         load_stmts = [swift_library_load_stmt]

--- a/swiftpkg/tests/pkginfo_targets_tests.bzl
+++ b/swiftpkg/tests/pkginfo_targets_tests.bzl
@@ -19,7 +19,7 @@ _bar_target = pkginfos.new_target(
     c99name = "Bar",
     module_type = module_types.swift,
     path = "Sources/Bar",
-    sources = [],
+    sources = ["Chicken.swift", "Smidgen/Hello.swift"],
     dependencies = [],
 )
 _foo_target = pkginfos.new_target(
@@ -81,7 +81,12 @@ bazel_label_test = unittest.make(_bazel_label_test)
 def _srcs_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    actual = pkginfo_targets.srcs(_bar_target)
+    expected = [
+        "Sources/Bar/Chicken.swift",
+        "Sources/Bar/Smidgen/Hello.swift",
+    ]
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 
@@ -90,7 +95,13 @@ srcs_test = unittest.make(_srcs_test)
 def _bazel_label_name_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    actual = pkginfo_targets.bazel_label_name(_bar_target)
+    expected = "Sources_Bar"
+    asserts.equals(env, expected, actual)
+
+    actual = pkginfo_targets.bazel_label_name(_chocolate_target)
+    expected = "Sources_Bar_Chocolate"
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 

--- a/swiftpkg/tests/pkginfo_targets_tests.bzl
+++ b/swiftpkg/tests/pkginfo_targets_tests.bzl
@@ -63,15 +63,15 @@ def _bazel_label_test(ctx):
     env = unittest.begin(ctx)
 
     actual = pkginfo_targets.bazel_label(_bar_target)
-    expected = "@example_cool_repo//:Sources/Bar"
+    expected = "@example_cool_repo//:Sources_Bar"
     asserts.equals(env, expected, actual)
 
     actual = pkginfo_targets.bazel_label(_foo_target, "@another_repo")
-    expected = "@another_repo//:Sources/Foo"
+    expected = "@another_repo//:Sources_Foo"
     asserts.equals(env, expected, actual)
 
     actual = pkginfo_targets.bazel_label(_chocolate_target)
-    expected = "@example_cool_repo//:Sources/Bar/Chocolate"
+    expected = "@example_cool_repo//:Sources_Bar_Chocolate"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)

--- a/swiftpkg/tests/pkginfo_targets_tests.bzl
+++ b/swiftpkg/tests/pkginfo_targets_tests.bzl
@@ -31,6 +31,15 @@ _foo_target = pkginfos.new_target(
     sources = [],
     dependencies = [],
 )
+_chocolate_target = pkginfos.new_target(
+    name = "Chocolate",
+    type = target_types.library,
+    c99name = "Chocolate",
+    module_type = module_types.swift,
+    path = "Sources/Bar",
+    sources = [],
+    dependencies = [],
+)
 
 def _get_test(ctx):
     env = unittest.begin(ctx)
@@ -54,20 +63,44 @@ def _bazel_label_test(ctx):
     env = unittest.begin(ctx)
 
     actual = pkginfo_targets.bazel_label(_bar_target)
-    expected = "@example_cool_repo//Sources/Bar"
+    expected = "@example_cool_repo//:Sources/Bar"
     asserts.equals(env, expected, actual)
 
     actual = pkginfo_targets.bazel_label(_foo_target, "@another_repo")
-    expected = "@another_repo//Sources/Foo"
+    expected = "@another_repo//:Sources/Foo"
+    asserts.equals(env, expected, actual)
+
+    actual = pkginfo_targets.bazel_label(_chocolate_target)
+    expected = "@example_cool_repo//:Sources/Bar/Chocolate"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 
 bazel_label_test = unittest.make(_bazel_label_test)
 
+def _srcs_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+srcs_test = unittest.make(_srcs_test)
+
+def _bazel_label_name_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+bazel_label_name_test = unittest.make(_bazel_label_name_test)
+
 def pkginfo_targets_test_suite():
     return unittest.suite(
         "pkginfo_targets_tests",
         get_test,
         bazel_label_test,
+        srcs_test,
+        bazel_label_name_test,
     )

--- a/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
@@ -103,9 +103,9 @@ _pkg_info = pkginfos.new(
 
 _module_index_json = """
 {
-  "swiftlint": ["@realm_swiftlint//Source/swiftlint"],
-  "SwiftLintFramework": ["@realm_swiftlint//Source/SwiftLintFramework"],
-  "SwiftLintFrameworkTests": ["@realm_swiftlint//Tests/SwiftLintFrameworkTests"]
+  "swiftlint": ["@realm_swiftlint//:Source/swiftlint"],
+  "SwiftLintFramework": ["@realm_swiftlint//:Source/SwiftLintFramework"],
+  "SwiftLintFrameworkTests": ["@realm_swiftlint//:Tests/SwiftLintFrameworkTests"]
 }
 """
 
@@ -127,13 +127,13 @@ def _swift_library_target_test(ctx):
         decls = [
             build_decls.new(
                 kind = swift_kinds.library,
-                name = "SwiftLintFramework",
+                name = "Source/SwiftLintFramework",
                 attrs = {
                     "defines": ["SWIFT_PACKAGE"],
                     "deps": [],
                     "module_name": "SwiftLintFramework",
                     "srcs": [
-                        "SwiftLintFramework.swift",
+                        "Source/SwiftLintFramework/SwiftLintFramework.swift",
                     ],
                     "visibility": ["//visibility:public"],
                 },
@@ -159,16 +159,16 @@ def _swift_library_target_for_binary_test(ctx):
         decls = [
             build_decls.new(
                 kind = swift_kinds.library,
-                name = "swiftlint",
+                name = "Source/swiftlint",
                 attrs = {
                     "defines": ["SWIFT_PACKAGE"],
                     "deps": [
-                        "@realm_swiftlint//Source/SwiftLintFramework",
+                        "@realm_swiftlint//:Source/SwiftLintFramework",
                     ],
                     "module_name": "swiftlint",
                     "srcs": [
-                        "Commands/SwiftLint.swift",
-                        "main.swift",
+                        "Source/swiftlint/Commands/SwiftLint.swift",
+                        "Source/swiftlint/main.swift",
                     ],
                     "visibility": ["//visibility:public"],
                 },
@@ -191,15 +191,15 @@ def _swift_test_target_test(ctx):
         decls = [
             build_decls.new(
                 kind = swift_kinds.test,
-                name = "SwiftLintFrameworkTests",
+                name = "Tests/SwiftLintFrameworkTests",
                 attrs = {
                     "defines": ["SWIFT_PACKAGE"],
                     "deps": [
-                        "@realm_swiftlint//Source/SwiftLintFramework",
+                        "@realm_swiftlint//:Source/SwiftLintFramework",
                     ],
                     "module_name": "SwiftLintFrameworkTests",
                     "srcs": [
-                        "SwiftLintFrameworkTests.swift",
+                        "Tests/SwiftLintFrameworkTests/SwiftLintFrameworkTests.swift",
                     ],
                     "visibility": ["//visibility:public"],
                 },
@@ -225,7 +225,7 @@ def _products_test(ctx):
                 kind = native_kinds.alias,
                 name = "SwiftLintFramework",
                 attrs = {
-                    "actual": "@realm_swiftlint//Source/SwiftLintFramework",
+                    "actual": "@realm_swiftlint//:Source/SwiftLintFramework",
                     "visibility": ["//visibility:public"],
                 },
             ),
@@ -233,7 +233,7 @@ def _products_test(ctx):
                 kind = swift_kinds.binary,
                 name = "swiftlint",
                 attrs = {
-                    "deps": ["@realm_swiftlint//Source/swiftlint"],
+                    "deps": ["@realm_swiftlint//:Source/swiftlint"],
                     "visibility": ["//visibility:public"],
                 },
             ),

--- a/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
@@ -103,9 +103,9 @@ _pkg_info = pkginfos.new(
 
 _module_index_json = """
 {
-  "swiftlint": ["@realm_swiftlint//:Source/swiftlint"],
-  "SwiftLintFramework": ["@realm_swiftlint//:Source/SwiftLintFramework"],
-  "SwiftLintFrameworkTests": ["@realm_swiftlint//:Tests/SwiftLintFrameworkTests"]
+  "swiftlint": ["@realm_swiftlint//:Source_swiftlint"],
+  "SwiftLintFramework": ["@realm_swiftlint//:Source_SwiftLintFramework"],
+  "SwiftLintFrameworkTests": ["@realm_swiftlint//:Tests_SwiftLintFrameworkTests"]
 }
 """
 
@@ -127,7 +127,7 @@ def _swift_library_target_test(ctx):
         decls = [
             build_decls.new(
                 kind = swift_kinds.library,
-                name = "Source/SwiftLintFramework",
+                name = "Source_SwiftLintFramework",
                 attrs = {
                     "defines": ["SWIFT_PACKAGE"],
                     "deps": [],
@@ -159,11 +159,11 @@ def _swift_library_target_for_binary_test(ctx):
         decls = [
             build_decls.new(
                 kind = swift_kinds.library,
-                name = "Source/swiftlint",
+                name = "Source_swiftlint",
                 attrs = {
                     "defines": ["SWIFT_PACKAGE"],
                     "deps": [
-                        "@realm_swiftlint//:Source/SwiftLintFramework",
+                        "@realm_swiftlint//:Source_SwiftLintFramework",
                     ],
                     "module_name": "swiftlint",
                     "srcs": [
@@ -191,11 +191,11 @@ def _swift_test_target_test(ctx):
         decls = [
             build_decls.new(
                 kind = swift_kinds.test,
-                name = "Tests/SwiftLintFrameworkTests",
+                name = "Tests_SwiftLintFrameworkTests",
                 attrs = {
                     "defines": ["SWIFT_PACKAGE"],
                     "deps": [
-                        "@realm_swiftlint//:Source/SwiftLintFramework",
+                        "@realm_swiftlint//:Source_SwiftLintFramework",
                     ],
                     "module_name": "SwiftLintFrameworkTests",
                     "srcs": [
@@ -225,7 +225,7 @@ def _products_test(ctx):
                 kind = native_kinds.alias,
                 name = "SwiftLintFramework",
                 attrs = {
-                    "actual": "@realm_swiftlint//:Source/SwiftLintFramework",
+                    "actual": "@realm_swiftlint//:Source_SwiftLintFramework",
                     "visibility": ["//visibility:public"],
                 },
             ),
@@ -233,7 +233,7 @@ def _products_test(ctx):
                 kind = swift_kinds.binary,
                 name = "swiftlint",
                 attrs = {
-                    "deps": ["@realm_swiftlint//:Source/swiftlint"],
+                    "deps": ["@realm_swiftlint//:Source_swiftlint"],
                     "visibility": ["//visibility:public"],
                 },
             ),


### PR DESCRIPTION
- Swift package targets are now generated with label names derived from their path and target name.
- All declarations for an external Swift package are generated in a single Bazel build file.

Related to #81.