### PR TITLE
chore: add example of Swift executable product pre-5.4

### DIFF
--- a/examples/pkg_manifest_minimal/do_test
+++ b/examples/pkg_manifest_minimal/do_test
@@ -10,9 +10,13 @@ bazel run //:tidy
 # Ensure that it builds and tests pass
 bazel test //...
 
-# Run the executable target
+# Run MyExecutable target
 output="$(bazel run //Sources/MyExecutable)"
 [[ "${output}" =~ "Good morning, World!" ]] || (echo >&2 "Expected 'Good morning, World!'"; exit 1)
+
+# Run old-style executable in my_local_package
+output="$(bazel run @swiftpkg_my_local_package//:print-greeting)"
+[[ "${output}" =~ "Good evening, Jim!" ]] || (echo >&2 "Expected 'Good evening, Jim!'"; exit 1)
 
 # Buid and run the SwiftFormat alias
 bazel run //:swiftformat -- --version

--- a/examples/pkg_manifest_minimal/module_index.json
+++ b/examples/pkg_manifest_minimal/module_index.json
@@ -41,6 +41,9 @@
   "LoggingTests": [
     "@swiftpkg_swift_log//:Tests_LoggingTests"
   ],
+  "PrintGreeting": [
+    "@swiftpkg_my_local_package//:Sources_PrintGreeting"
+  ],
   "SwiftFormat": [
     "@swiftpkg_swiftformat//:Sources_SwiftFormat"
   ],

--- a/examples/pkg_manifest_minimal/third_party/my_local_package/Package.swift
+++ b/examples/pkg_manifest_minimal/third_party/my_local_package/Package.swift
@@ -1,20 +1,23 @@
 // swift-tools-version: 5.7
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "MyLocalPackage",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .executable(name: "print-greeting", targets: ["PrintGreeting"]),
         .library(
             name: "GreetingsFramework",
             targets: ["GreetingsFramework"]
         ),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        // Puposefully, using the old-style pattern of a regular target being used by an executable
+        // product.
+        .target(
+            name: "PrintGreeting",
+            dependencies: ["GreetingsFramework"]
+        ),
         .target(
             name: "GreetingsFramework",
             dependencies: []

--- a/examples/pkg_manifest_minimal/third_party/my_local_package/Sources/GreetingsFramework/EveningGreeting.swift
+++ b/examples/pkg_manifest_minimal/third_party/my_local_package/Sources/GreetingsFramework/EveningGreeting.swift
@@ -1,0 +1,9 @@
+public struct EveningGreeting {
+    public init() {}
+}
+
+extension EveningGreeting: GreetingProvider {
+    public var greeting: String {
+        return "Good evening"
+    }
+}

--- a/examples/pkg_manifest_minimal/third_party/my_local_package/Sources/GreetingsFramework/WithName.swift
+++ b/examples/pkg_manifest_minimal/third_party/my_local_package/Sources/GreetingsFramework/WithName.swift
@@ -1,0 +1,7 @@
+public struct WithName: NameProvider {
+    public let name: String
+
+    public init(_ name: String) {
+        self.name = name
+    }
+}

--- a/examples/pkg_manifest_minimal/third_party/my_local_package/Sources/PrintGreeting/main.swift
+++ b/examples/pkg_manifest_minimal/third_party/my_local_package/Sources/PrintGreeting/main.swift
@@ -1,0 +1,5 @@
+import GreetingsFramework
+
+let jim = WithName("Jim")
+let namedGreeting = NamedGreeting(EveningGreeting(), jim)
+print(namedGreeting.value)

--- a/examples/pkg_manifest_minimal/third_party/my_local_package/Tests/GreetingsFrameworkTests/EveningGreetingTests.swift
+++ b/examples/pkg_manifest_minimal/third_party/my_local_package/Tests/GreetingsFrameworkTests/EveningGreetingTests.swift
@@ -1,0 +1,8 @@
+@testable import GreetingsFramework
+import XCTest
+
+final class EveningGreetingTests: XCTestCase {
+    func testExample() throws {
+        XCTAssertEqual(EveningGreeting().greeting, "Good evening")
+    }
+}

--- a/examples/pkg_manifest_minimal/third_party/my_local_package/Tests/GreetingsFrameworkTests/WithNameTests.swift
+++ b/examples/pkg_manifest_minimal/third_party/my_local_package/Tests/GreetingsFrameworkTests/WithNameTests.swift
@@ -1,0 +1,9 @@
+@testable import GreetingsFramework
+import XCTest
+
+class WithNameTests: XCTestCase {
+    func test_init() throws {
+        let withName = WithName("George")
+        XCTAssertEqual(withName.name, "George")
+    }
+}

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -137,6 +137,8 @@ def _executable_product_build_file(pkg_info, product, repo_name):
                 ],
             )
         else:
+            # This is an old-style (pre-5.4) configuration where an executable
+            # product references a regular target.
             # Create the binary target here.
             return build_files.new(
                 load_stmts = [load_statements.new(swift_location, swift_kinds.binary)],


### PR DESCRIPTION
- Add `print-greeting` product to `my_local_package`.
- Update `do_test` in `pkg_manifest_minimal` to call `print-greeting`.

Related to #52.