### PR TITLE
chore: rename `TargetName` to `Name` in `ByNameReference`

### DIFF
--- a/gazelle/internal/spdump/manifest_test.go
+++ b/gazelle/internal/spdump/manifest_test.go
@@ -61,7 +61,7 @@ func TestNewManifestFromJSON(t *testing.T) {
 				Type: spdump.TestTargetType,
 				Dependencies: []spdump.TargetDependency{
 					{
-						ByName: &spdump.ByNameReference{TargetName: "MySwiftPackage"},
+						ByName: &spdump.ByNameReference{Name: "MySwiftPackage"},
 					},
 				},
 			},

--- a/gazelle/internal/spdump/target_dependency.go
+++ b/gazelle/internal/spdump/target_dependency.go
@@ -17,7 +17,7 @@ func (td *TargetDependency) ImportName() string {
 	if td.Product != nil {
 		return td.Product.ProductName
 	} else if td.ByName != nil {
-		return td.ByName.TargetName
+		return td.ByName.Name
 	}
 	return ""
 }
@@ -51,10 +51,10 @@ func (pr *ProductReference) UniqKey() string {
 
 // ByNameReference
 
-// Reference a target by name
+// Reference a product or target by name
 type ByNameReference struct {
-	// GH084: Should this be Name? Can it refer to a target or a product?
-	TargetName string
+	// Product name or target name
+	Name string
 }
 
 func (bnr *ByNameReference) UnmarshalJSON(b []byte) error {
@@ -63,7 +63,7 @@ func (bnr *ByNameReference) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	if bnr.TargetName, err = jsonutils.StringAtIndex(raw, 0); err != nil {
+	if bnr.Name, err = jsonutils.StringAtIndex(raw, 0); err != nil {
 		return err
 	}
 	return nil

--- a/gazelle/internal/spdump/target_dependency_test.go
+++ b/gazelle/internal/spdump/target_dependency_test.go
@@ -20,7 +20,7 @@ func TestTargetDependencyImportName(t *testing.T) {
 	})
 	t.Run("by name", func(t *testing.T) {
 		td := spdump.TargetDependency{
-			ByName: &spdump.ByNameReference{TargetName: "MySwiftPackage"},
+			ByName: &spdump.ByNameReference{Name: "MySwiftPackage"},
 		}
 		actual := td.ImportName()
 		assert.Equal(t, "MySwiftPackage", actual)

--- a/gazelle/internal/spdump/target_test.go
+++ b/gazelle/internal/spdump/target_test.go
@@ -19,7 +19,7 @@ func TestTargetImports(t *testing.T) {
 				},
 			},
 			{
-				ByName: &spdump.ByNameReference{TargetName: "MySwiftPackage"},
+				ByName: &spdump.ByNameReference{Name: "MySwiftPackage"},
 			},
 		},
 	}

--- a/gazelle/internal/swiftpkg/target_dependency.go
+++ b/gazelle/internal/swiftpkg/target_dependency.go
@@ -72,7 +72,7 @@ type ByNameReference struct {
 
 func NewByNameReferenceFromManifestInfo(dumpBNR *spdump.ByNameReference) *ByNameReference {
 	return &ByNameReference{
-		Name: dumpBNR.TargetName,
+		Name: dumpBNR.Name,
 	}
 }
 

--- a/gazelle/internal/swiftpkg/target_dependency.go
+++ b/gazelle/internal/swiftpkg/target_dependency.go
@@ -36,7 +36,7 @@ func (td *TargetDependency) ImportName() string {
 	if td.Product != nil {
 		return td.Product.ProductName
 	} else if td.ByName != nil {
-		return td.ByName.TargetName
+		return td.ByName.Name
 	}
 	return ""
 }
@@ -64,15 +64,15 @@ func (pr *ProductReference) UniqKey() string {
 
 // ByNameReference
 
-// Reference a target by name
+// Reference a product or target by name.
 type ByNameReference struct {
-	// GH084: Should this be Name? Can it refer to a target or a product?
-	TargetName string
+	// Product name or target name
+	Name string
 }
 
 func NewByNameReferenceFromManifestInfo(dumpBNR *spdump.ByNameReference) *ByNameReference {
 	return &ByNameReference{
-		TargetName: dumpBNR.TargetName,
+		Name: dumpBNR.TargetName,
 	}
 }
 


### PR DESCRIPTION
Closes #84 