### PR TITLE
chore: address issues getting `vapor_example` working

### DIFF
--- a/gazelle/internal/spdump/manifest_test.go
+++ b/gazelle/internal/spdump/manifest_test.go
@@ -55,6 +55,7 @@ func TestNewManifestFromJSON(t *testing.T) {
 						},
 					},
 				},
+				Settings: []spdump.TargetSetting{},
 			},
 			{
 				Name: "MySwiftPackageTests",
@@ -64,6 +65,7 @@ func TestNewManifestFromJSON(t *testing.T) {
 						ByName: &spdump.ByNameReference{Name: "MySwiftPackage"},
 					},
 				},
+				Settings: []spdump.TargetSetting{},
 			},
 		},
 	}

--- a/gazelle/internal/spdump/target_test.go
+++ b/gazelle/internal/spdump/target_test.go
@@ -1,6 +1,7 @@
 package spdump_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/cgrindel/swift_bazel/gazelle/internal/spdump"
@@ -41,3 +42,31 @@ func TestTargetsByName(t *testing.T) {
 	actual = targets.FindByName("DoesNotExist")
 	assert.Nil(t, actual)
 }
+
+func TestTargetSettingUnmarshalJSON(t *testing.T) {
+	expected := []spdump.TargetSetting{
+		{
+			Tool:    spdump.ClangToolType,
+			Kind:    spdump.DefineTargetSettingKind,
+			Defines: []string{"__APPLE_USE_RFC_3542"},
+		},
+	}
+
+	var settings []spdump.TargetSetting
+	err := json.Unmarshal([]byte(targetSettingsJSON), &settings)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, settings)
+}
+
+const targetSettingsJSON = `
+[
+  {
+    "kind" : {
+      "define" : {
+        "_0" : "__APPLE_USE_RFC_3542"
+      }
+    },
+    "tool" : "c"
+  }
+]
+`

--- a/gazelle/internal/swiftpkg/target.go
+++ b/gazelle/internal/swiftpkg/target.go
@@ -51,6 +51,7 @@ type Target struct {
 	Path         string
 	Sources      []string
 	Dependencies []*TargetDependency
+	CSettings    *ClangSettings
 }
 
 func NewTargetFromManifestInfo(descT *spdesc.Target, dumpT *spdump.Target) (*Target, error) {
@@ -83,6 +84,11 @@ func NewTargetFromManifestInfo(descT *spdesc.Target, dumpT *spdump.Target) (*Tar
 		}
 	}
 
+	cSettings, err := NewClangSettingsFromManifestInfo(dumpT.Settings)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Target{
 		Name:         descT.Name,
 		C99name:      descT.C99name,
@@ -91,6 +97,7 @@ func NewTargetFromManifestInfo(descT *spdesc.Target, dumpT *spdump.Target) (*Tar
 		Path:         descT.Path,
 		Sources:      descT.Sources,
 		Dependencies: tdeps,
+		CSettings:    cSettings,
 	}, nil
 }
 
@@ -100,4 +107,23 @@ func (t *Target) Imports() []string {
 		imports[idx] = td.ImportName()
 	}
 	return imports
+}
+
+// ClangSettings
+
+type ClangSettings struct {
+	Defines []string
+}
+
+func NewClangSettingsFromManifestInfo(dumpTS []spdump.TargetSetting) (*ClangSettings, error) {
+	cSettings := &ClangSettings{}
+	for _, ts := range dumpTS {
+		if ts.Tool != spdump.ClangToolType {
+			continue
+		}
+		if ts.Kind == spdump.DefineTargetSettingKind {
+			cSettings.Defines = append(cSettings.Defines, ts.Defines...)
+		}
+	}
+	return cSettings, nil
 }

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -4,7 +4,6 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("//swiftpkg/internal/modulemap_parser:declarations.bzl", dts = "declaration_types")
 load("//swiftpkg/internal/modulemap_parser:parser.bzl", modulemap_parser = "parser")
-load(":repository_files.bzl", "repository_files")
 
 # Directory names that may include public header files.
 _PUBLIC_HDR_DIRNAMES = ["include", "public"]
@@ -84,10 +83,11 @@ def _get_hdr_paths_from_modulemap(repository_ctx, modulemap_path):
     return hdrs
 
 def _remove_prefix(path, prefix):
-    if prefix == None or path == None:
-        return path
-    prefix_len = len(prefix)
-    return path[prefix_len:] if path.startswith(prefix) else path
+    # if prefix == None or path == None:
+    #     return path
+    # prefix_len = len(prefix)
+    # return path[prefix_len:] if path.startswith(prefix) else path
+    return _remove_prefixes([path], prefix)[0]
 
 def _remove_prefixes(paths_list, prefix):
     if prefix == None:
@@ -98,20 +98,99 @@ def _remove_prefixes(paths_list, prefix):
         for path in paths_list
     ]
 
-def _collect_files(
-        repository_ctx,
-        root_paths,
-        public_includes = None,
-        remove_prefix = None):
-    paths_list = []
-    for root_path in root_paths:
-        paths_list.extend(
-            repository_files.list_files_under(
-                repository_ctx,
-                root_path,
-            ),
-        )
+# def _collect_files(
+#         repository_ctx,
+#         root_paths,
+#         public_includes = None,
+#         remove_prefix = None):
+#     paths_list = []
+#     for root_path in root_paths:
+#         paths_list.extend(
+#             repository_files.list_files_under(
+#                 repository_ctx,
+#                 root_path,
+#             ),
+#         )
 
+#     # hdrs: Public headers
+#     # srcs: Private headers and source files.
+#     # others: Uncategorized
+#     # modulemap: Public modulemap
+#     hdrs_set = sets.make()
+#     srcs_set = sets.make()
+#     others_set = sets.make()
+#     includes_set = sets.make()
+#     modulemap = None
+#     modulemap_orig_path = None
+#     for orig_path in paths_list:
+#         path = _remove_prefix(orig_path, remove_prefix)
+#         _root, ext = paths.split_extension(path)
+#         if ext == ".h":
+#             if _is_include_hdr(orig_path, public_includes = public_includes):
+#                 sets.insert(hdrs_set, path)
+#                 sets.insert(includes_set, paths.dirname(path))
+#             else:
+#                 sets.insert(srcs_set, path)
+#         elif ext == ".c":
+#             sets.insert(srcs_set, path)
+#         elif ext == ".modulemap" and _is_public_modulemap(path):
+#             if modulemap != None:
+#                 fail("Found multiple modulemap files. {first} {second}".format(
+#                     first = modulemap,
+#                     second = path,
+#                 ))
+#             modulemap_orig_path = orig_path
+#             modulemap = path
+#         else:
+#             sets.insert(others_set, path)
+
+#     srcs = sets.to_list(srcs_set)
+#     others = sets.to_list(others_set)
+
+#     # Add each directory that contains a private header to the includes
+#     private_hdr_dirs = sets.make([
+#         paths.dirname(src)
+#         for src in srcs
+#         if _is_hdr(src)
+#     ])
+#     includes_set = sets.union(includes_set, private_hdr_dirs)
+
+#     # Be sure to add any parent directories to the includes list
+#     # Some clang files reference their header files from different relative paths
+#     for include in sets.to_list(includes_set):
+#         parts = include.split("/")
+#         for idx, _part in enumerate(parts):
+#             path = "/".join(parts[0:idx])
+#             if path != "":
+#                 sets.insert(includes_set, path)
+
+#     includes = sets.to_list(includes_set)
+
+#     # If we found a public modulemap, get the headers from there. This
+#     # overrides any hdrs that we found by inspection.
+#     if modulemap_orig_path != None:
+#         hdrs = _get_hdr_paths_from_modulemap(
+#             repository_ctx,
+#             modulemap_orig_path,
+#         )
+#         hdrs = _remove_prefixes(hdrs, remove_prefix)
+#     else:
+#         hdrs = sets.to_list(hdrs_set)
+
+#     # Remove the prefixes before returning the results
+#     return struct(
+#         hdrs = sorted(hdrs),
+#         srcs = sorted(srcs),
+#         includes = sorted(includes),
+#         modulemap = modulemap,
+#         others = sorted(others),
+#     )
+
+# files: list of file paths as strings
+# pkg_dir: the directory for the package that includes the files
+# def _organize(repository_ctx, pkg_dir, files):
+
+def _organize(files):
     # hdrs: Public headers
     # srcs: Private headers and source files.
     # others: Uncategorized
@@ -121,12 +200,11 @@ def _collect_files(
     others_set = sets.make()
     includes_set = sets.make()
     modulemap = None
-    modulemap_orig_path = None
-    for orig_path in paths_list:
-        path = _remove_prefix(orig_path, remove_prefix)
+    for path in files:
         _root, ext = paths.split_extension(path)
         if ext == ".h":
-            if _is_include_hdr(orig_path, public_includes = public_includes):
+            # TODO(chuck): Should I plumb through public_includes?
+            if _is_include_hdr(path):
                 sets.insert(hdrs_set, path)
                 sets.insert(includes_set, paths.dirname(path))
             else:
@@ -139,7 +217,6 @@ def _collect_files(
                     first = modulemap,
                     second = path,
                 ))
-            modulemap_orig_path = orig_path
             modulemap = path
         else:
             sets.insert(others_set, path)
@@ -155,27 +232,12 @@ def _collect_files(
     ])
     includes_set = sets.union(includes_set, private_hdr_dirs)
 
-    # Be sure to add any parent directories to the includes list
-    # Some clang files reference their header files from different relative paths
-    for include in sets.to_list(includes_set):
-        parts = include.split("/")
-        for idx, _part in enumerate(parts):
-            path = "/".join(parts[0:idx])
-            if path != "":
-                sets.insert(includes_set, path)
+    # TODO(chuck): Do we need to handle the relative paths to header files?
+
+    # TODO(chuck): Add code to read a public modulemap
 
     includes = sets.to_list(includes_set)
-
-    # If we found a public modulemap, get the headers from there. This
-    # overrides any hdrs that we found by inspection.
-    if modulemap_orig_path != None:
-        hdrs = _get_hdr_paths_from_modulemap(
-            repository_ctx,
-            modulemap_orig_path,
-        )
-        hdrs = _remove_prefixes(hdrs, remove_prefix)
-    else:
-        hdrs = sets.to_list(hdrs_set)
+    hdrs = sets.to_list(hdrs_set)
 
     # Remove the prefixes before returning the results
     return struct(
@@ -190,6 +252,6 @@ clang_files = struct(
     is_hdr = _is_hdr,
     is_include_hdr = _is_include_hdr,
     is_public_modulemap = _is_public_modulemap,
-    collect_files = _collect_files,
+    # collect_files = _collect_files,
     get_hdr_paths_from_modulemap = _get_hdr_paths_from_modulemap,
 )

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:sets.bzl", "sets")
+load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "lists")
 load("//swiftpkg/internal/modulemap_parser:declarations.bzl", dts = "declaration_types")
 load("//swiftpkg/internal/modulemap_parser:parser.bzl", modulemap_parser = "parser")
 load(":repository_files.bzl", "repository_files")
@@ -132,7 +133,8 @@ def _collect_files(
                 sets.insert(public_includes_set, paths.dirname(path))
             else:
                 sets.insert(srcs_set, path)
-        elif ext == ".c":
+        elif lists.contains([".c", ".S", ".so", ".o"], ext):
+            # Acceptable sources: https://bazel.build/reference/be/c-cpp#cc_library.srcs
             sets.insert(srcs_set, path)
         elif ext == ".modulemap" and _is_public_modulemap(path):
             if modulemap != None:

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -85,10 +85,6 @@ def _get_hdr_paths_from_modulemap(repository_ctx, modulemap_path):
     return hdrs
 
 def _remove_prefix(path, prefix):
-    # if prefix == None or path == None:
-    #     return path
-    # prefix_len = len(prefix)
-    # return path[prefix_len:] if path.startswith(prefix) else path
     return _remove_prefixes([path], prefix)[0]
 
 def _remove_prefixes(paths_list, prefix):

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -120,7 +120,7 @@ def _collect_files(
     hdrs_set = sets.make()
     srcs_set = sets.make()
     others_set = sets.make()
-    includes_set = sets.make()
+    public_includes_set = sets.make()
     modulemap = None
     modulemap_orig_path = None
     for orig_path in paths_list:
@@ -129,7 +129,7 @@ def _collect_files(
         if ext == ".h":
             if _is_include_hdr(orig_path, public_includes = public_includes):
                 sets.insert(hdrs_set, path)
-                sets.insert(includes_set, paths.dirname(path))
+                sets.insert(public_includes_set, paths.dirname(path))
             else:
                 sets.insert(srcs_set, path)
         elif ext == ".c":
@@ -149,23 +149,23 @@ def _collect_files(
     others = sets.to_list(others_set)
 
     # Add each directory that contains a private header to the includes
-    private_hdr_dirs = sets.make([
+    private_includes_set = sets.make([
         paths.dirname(src)
         for src in srcs
         if _is_hdr(src)
     ])
-    includes_set = sets.union(includes_set, private_hdr_dirs)
 
     # # Be sure to add any parent directories to the includes list
     # # Some clang files reference their header files from different relative paths
-    # for include in sets.to_list(includes_set):
+    # for include in sets.to_list(public_includes_set):
     #     parts = include.split("/")
     #     for idx, _part in enumerate(parts):
     #         path = "/".join(parts[0:idx])
     #         if path != "":
-    #             sets.insert(includes_set, path)
+    #             sets.insert(public_includes_set, path)
 
-    includes = sets.to_list(includes_set)
+    public_includes = sets.to_list(public_includes_set)
+    private_includes = sets.to_list(private_includes_set)
 
     # If we found a public modulemap, get the headers from there. This
     # overrides any hdrs that we found by inspection.
@@ -182,78 +182,16 @@ def _collect_files(
     return struct(
         hdrs = sorted(hdrs),
         srcs = sorted(srcs),
-        includes = sorted(includes),
+        public_includes = sorted(public_includes),
+        private_includes = sorted(private_includes),
         modulemap = modulemap,
         others = sorted(others),
     )
-
-# files: list of file paths as strings
-# pkg_dir: the directory for the package that includes the files
-# def _organize(repository_ctx, pkg_dir, files):
-
-# def _organize(files):
-#     # hdrs: Public headers
-#     # srcs: Private headers and source files.
-#     # others: Uncategorized
-#     # modulemap: Public modulemap
-#     hdrs_set = sets.make()
-#     srcs_set = sets.make()
-#     others_set = sets.make()
-#     includes_set = sets.make()
-#     modulemap = None
-#     for path in files:
-#         _root, ext = paths.split_extension(path)
-#         if ext == ".h":
-#             # TODO(chuck): Should I plumb through public_includes?
-#             if _is_include_hdr(path):
-#                 sets.insert(hdrs_set, path)
-#                 sets.insert(includes_set, paths.dirname(path))
-#             else:
-#                 sets.insert(srcs_set, path)
-#         elif ext == ".c":
-#             sets.insert(srcs_set, path)
-#         elif ext == ".modulemap" and _is_public_modulemap(path):
-#             if modulemap != None:
-#                 fail("Found multiple modulemap files. {first} {second}".format(
-#                     first = modulemap,
-#                     second = path,
-#                 ))
-#             modulemap = path
-#         else:
-#             sets.insert(others_set, path)
-
-#     srcs = sets.to_list(srcs_set)
-#     others = sets.to_list(others_set)
-
-#     # Add each directory that contains a private header to the includes
-#     private_hdr_dirs = sets.make([
-#         paths.dirname(src)
-#         for src in srcs
-#         if _is_hdr(src)
-#     ])
-#     includes_set = sets.union(includes_set, private_hdr_dirs)
-
-#     # TODO(chuck): Do we need to handle the relative paths to header files?
-
-#     # TODO(chuck): Add code to read a public modulemap
-
-#     includes = sets.to_list(includes_set)
-#     hdrs = sets.to_list(hdrs_set)
-
-#     # Remove the prefixes before returning the results
-#     return struct(
-#         hdrs = sorted(hdrs),
-#         srcs = sorted(srcs),
-#         includes = sorted(includes),
-#         modulemap = modulemap,
-#         others = sorted(others),
-#     )
 
 clang_files = struct(
     is_hdr = _is_hdr,
     is_include_hdr = _is_include_hdr,
     is_public_modulemap = _is_public_modulemap,
     collect_files = _collect_files,
-    # organize = _organize,
     get_hdr_paths_from_modulemap = _get_hdr_paths_from_modulemap,
 )

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("//swiftpkg/internal/modulemap_parser:declarations.bzl", dts = "declaration_types")
 load("//swiftpkg/internal/modulemap_parser:parser.bzl", modulemap_parser = "parser")
+load(":repository_files.bzl", "repository_files")
 
 # Directory names that may include public header files.
 _PUBLIC_HDR_DIRNAMES = ["include", "public"]
@@ -98,99 +99,20 @@ def _remove_prefixes(paths_list, prefix):
         for path in paths_list
     ]
 
-# def _collect_files(
-#         repository_ctx,
-#         root_paths,
-#         public_includes = None,
-#         remove_prefix = None):
-#     paths_list = []
-#     for root_path in root_paths:
-#         paths_list.extend(
-#             repository_files.list_files_under(
-#                 repository_ctx,
-#                 root_path,
-#             ),
-#         )
+def _collect_files(
+        repository_ctx,
+        root_paths,
+        public_includes = None,
+        remove_prefix = None):
+    paths_list = []
+    for root_path in root_paths:
+        paths_list.extend(
+            repository_files.list_files_under(
+                repository_ctx,
+                root_path,
+            ),
+        )
 
-#     # hdrs: Public headers
-#     # srcs: Private headers and source files.
-#     # others: Uncategorized
-#     # modulemap: Public modulemap
-#     hdrs_set = sets.make()
-#     srcs_set = sets.make()
-#     others_set = sets.make()
-#     includes_set = sets.make()
-#     modulemap = None
-#     modulemap_orig_path = None
-#     for orig_path in paths_list:
-#         path = _remove_prefix(orig_path, remove_prefix)
-#         _root, ext = paths.split_extension(path)
-#         if ext == ".h":
-#             if _is_include_hdr(orig_path, public_includes = public_includes):
-#                 sets.insert(hdrs_set, path)
-#                 sets.insert(includes_set, paths.dirname(path))
-#             else:
-#                 sets.insert(srcs_set, path)
-#         elif ext == ".c":
-#             sets.insert(srcs_set, path)
-#         elif ext == ".modulemap" and _is_public_modulemap(path):
-#             if modulemap != None:
-#                 fail("Found multiple modulemap files. {first} {second}".format(
-#                     first = modulemap,
-#                     second = path,
-#                 ))
-#             modulemap_orig_path = orig_path
-#             modulemap = path
-#         else:
-#             sets.insert(others_set, path)
-
-#     srcs = sets.to_list(srcs_set)
-#     others = sets.to_list(others_set)
-
-#     # Add each directory that contains a private header to the includes
-#     private_hdr_dirs = sets.make([
-#         paths.dirname(src)
-#         for src in srcs
-#         if _is_hdr(src)
-#     ])
-#     includes_set = sets.union(includes_set, private_hdr_dirs)
-
-#     # Be sure to add any parent directories to the includes list
-#     # Some clang files reference their header files from different relative paths
-#     for include in sets.to_list(includes_set):
-#         parts = include.split("/")
-#         for idx, _part in enumerate(parts):
-#             path = "/".join(parts[0:idx])
-#             if path != "":
-#                 sets.insert(includes_set, path)
-
-#     includes = sets.to_list(includes_set)
-
-#     # If we found a public modulemap, get the headers from there. This
-#     # overrides any hdrs that we found by inspection.
-#     if modulemap_orig_path != None:
-#         hdrs = _get_hdr_paths_from_modulemap(
-#             repository_ctx,
-#             modulemap_orig_path,
-#         )
-#         hdrs = _remove_prefixes(hdrs, remove_prefix)
-#     else:
-#         hdrs = sets.to_list(hdrs_set)
-
-#     # Remove the prefixes before returning the results
-#     return struct(
-#         hdrs = sorted(hdrs),
-#         srcs = sorted(srcs),
-#         includes = sorted(includes),
-#         modulemap = modulemap,
-#         others = sorted(others),
-#     )
-
-# files: list of file paths as strings
-# pkg_dir: the directory for the package that includes the files
-# def _organize(repository_ctx, pkg_dir, files):
-
-def _organize(files):
     # hdrs: Public headers
     # srcs: Private headers and source files.
     # others: Uncategorized
@@ -200,11 +122,12 @@ def _organize(files):
     others_set = sets.make()
     includes_set = sets.make()
     modulemap = None
-    for path in files:
+    modulemap_orig_path = None
+    for orig_path in paths_list:
+        path = _remove_prefix(orig_path, remove_prefix)
         _root, ext = paths.split_extension(path)
         if ext == ".h":
-            # TODO(chuck): Should I plumb through public_includes?
-            if _is_include_hdr(path):
+            if _is_include_hdr(orig_path, public_includes = public_includes):
                 sets.insert(hdrs_set, path)
                 sets.insert(includes_set, paths.dirname(path))
             else:
@@ -217,6 +140,7 @@ def _organize(files):
                     first = modulemap,
                     second = path,
                 ))
+            modulemap_orig_path = orig_path
             modulemap = path
         else:
             sets.insert(others_set, path)
@@ -232,12 +156,27 @@ def _organize(files):
     ])
     includes_set = sets.union(includes_set, private_hdr_dirs)
 
-    # TODO(chuck): Do we need to handle the relative paths to header files?
-
-    # TODO(chuck): Add code to read a public modulemap
+    # # Be sure to add any parent directories to the includes list
+    # # Some clang files reference their header files from different relative paths
+    # for include in sets.to_list(includes_set):
+    #     parts = include.split("/")
+    #     for idx, _part in enumerate(parts):
+    #         path = "/".join(parts[0:idx])
+    #         if path != "":
+    #             sets.insert(includes_set, path)
 
     includes = sets.to_list(includes_set)
-    hdrs = sets.to_list(hdrs_set)
+
+    # If we found a public modulemap, get the headers from there. This
+    # overrides any hdrs that we found by inspection.
+    if modulemap_orig_path != None:
+        hdrs = _get_hdr_paths_from_modulemap(
+            repository_ctx,
+            modulemap_orig_path,
+        )
+        hdrs = _remove_prefixes(hdrs, remove_prefix)
+    else:
+        hdrs = sets.to_list(hdrs_set)
 
     # Remove the prefixes before returning the results
     return struct(
@@ -248,10 +187,73 @@ def _organize(files):
         others = sorted(others),
     )
 
+# files: list of file paths as strings
+# pkg_dir: the directory for the package that includes the files
+# def _organize(repository_ctx, pkg_dir, files):
+
+# def _organize(files):
+#     # hdrs: Public headers
+#     # srcs: Private headers and source files.
+#     # others: Uncategorized
+#     # modulemap: Public modulemap
+#     hdrs_set = sets.make()
+#     srcs_set = sets.make()
+#     others_set = sets.make()
+#     includes_set = sets.make()
+#     modulemap = None
+#     for path in files:
+#         _root, ext = paths.split_extension(path)
+#         if ext == ".h":
+#             # TODO(chuck): Should I plumb through public_includes?
+#             if _is_include_hdr(path):
+#                 sets.insert(hdrs_set, path)
+#                 sets.insert(includes_set, paths.dirname(path))
+#             else:
+#                 sets.insert(srcs_set, path)
+#         elif ext == ".c":
+#             sets.insert(srcs_set, path)
+#         elif ext == ".modulemap" and _is_public_modulemap(path):
+#             if modulemap != None:
+#                 fail("Found multiple modulemap files. {first} {second}".format(
+#                     first = modulemap,
+#                     second = path,
+#                 ))
+#             modulemap = path
+#         else:
+#             sets.insert(others_set, path)
+
+#     srcs = sets.to_list(srcs_set)
+#     others = sets.to_list(others_set)
+
+#     # Add each directory that contains a private header to the includes
+#     private_hdr_dirs = sets.make([
+#         paths.dirname(src)
+#         for src in srcs
+#         if _is_hdr(src)
+#     ])
+#     includes_set = sets.union(includes_set, private_hdr_dirs)
+
+#     # TODO(chuck): Do we need to handle the relative paths to header files?
+
+#     # TODO(chuck): Add code to read a public modulemap
+
+#     includes = sets.to_list(includes_set)
+#     hdrs = sets.to_list(hdrs_set)
+
+#     # Remove the prefixes before returning the results
+#     return struct(
+#         hdrs = sorted(hdrs),
+#         srcs = sorted(srcs),
+#         includes = sorted(includes),
+#         modulemap = modulemap,
+#         others = sorted(others),
+#     )
+
 clang_files = struct(
     is_hdr = _is_hdr,
     is_include_hdr = _is_include_hdr,
     is_public_modulemap = _is_public_modulemap,
-    # collect_files = _collect_files,
+    collect_files = _collect_files,
+    # organize = _organize,
     get_hdr_paths_from_modulemap = _get_hdr_paths_from_modulemap,
 )

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -167,16 +167,21 @@ def _collect_files(
     public_includes = sets.to_list(public_includes_set)
     private_includes = sets.to_list(private_includes_set)
 
-    # If we found a public modulemap, get the headers from there. This
-    # overrides any hdrs that we found by inspection.
+    # The apple/swift-crypto package has a CCryptoBoringSSL target that has a
+    # modulemap in their include directory, but it only lists the top-level
+    # header. The modulemap spec suggests that the header is parsed and all of
+    # the referenced headers are included. For now, we will just add the
+    # modulempa hdrs to the ones that we have already found.
     if modulemap_orig_path != None:
-        hdrs = _get_hdr_paths_from_modulemap(
+        mm_hdrs = _get_hdr_paths_from_modulemap(
             repository_ctx,
             modulemap_orig_path,
         )
-        hdrs = _remove_prefixes(hdrs, remove_prefix)
-    else:
-        hdrs = sets.to_list(hdrs_set)
+        mm_hdrs = _remove_prefixes(mm_hdrs, remove_prefix)
+        mm_hdrs_set = sets.make(mm_hdrs)
+        hdrs_set = sets.union(hdrs_set, mm_hdrs_set)
+
+    hdrs = sets.to_list(hdrs_set)
 
     # Remove the prefixes before returning the results
     return struct(

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -147,6 +147,11 @@ def _new_target_from_json_maps(dump_map, desc_map):
         _new_target_dependency_from_dump_json_map(d)
         for d in dump_map["dependencies"]
     ]
+
+    clang_settings = _new_clang_settings_from_dump_json_list(
+        dump_map["settings"],
+    )
+
     return _new_target(
         name = dump_map["name"],
         type = dump_map["type"],
@@ -155,6 +160,23 @@ def _new_target_from_json_maps(dump_map, desc_map):
         path = desc_map["path"],
         sources = desc_map["sources"],
         dependencies = dependencies,
+        clang_settings = clang_settings,
+    )
+
+def _new_clang_settings_from_dump_json_list(dump_list):
+    defines = []
+    for setting in dump_list:
+        if setting["tool"] != "c":
+            continue
+        kind_map = setting["kind"]
+        define_map = kind_map["define"]
+        for (k, define) in define_map.items():
+            defines.append(define)
+
+    if len(defines) == 0:
+        return None
+    return _new_clang_settings(
+        defines = defines,
     )
 
 def _new_from_parsed_json(dump_manifest, desc_manifest):
@@ -446,7 +468,7 @@ A target dependency must have one of the following: `by_name`, `product`, `targe
         target = target,
     )
 
-def _new_target(name, type, c99name, module_type, path, sources, dependencies):
+def _new_target(name, type, c99name, module_type, path, sources, dependencies, clang_settings = None):
     """Creates a target.
 
     Args:
@@ -459,6 +481,7 @@ def _new_target(name, type, c99name, module_type, path, sources, dependencies):
             to the `path`.
         dependencies: A `list` of target dependency values as returned by
             `pkginfos.new_target_dependency()`.
+        clang_settings: Optional. A `struct` as returned by `pkginfos.new_clang_settings`.
 
     Returns:
         A `struct` representing a target in a Swift package.
@@ -481,6 +504,12 @@ def _new_target(name, type, c99name, module_type, path, sources, dependencies):
         path = path,
         sources = sources,
         dependencies = dependencies,
+        clang_settings = clang_settings,
+    )
+
+def _new_clang_settings(defines):
+    return struct(
+        defines = defines,
     )
 
 target_types = struct(
@@ -523,17 +552,18 @@ library_type_kinds = struct(
 pkginfos = struct(
     get = _get,
     new = _new,
-    new_from_parsed_json = _new_from_parsed_json,
-    new_platform = _new_platform,
+    new_by_name_reference = _new_by_name_reference,
+    new_clang_settings = _new_clang_settings,
     new_dependency = _new_dependency,
     new_dependency_requirement = _new_dependency_requirement,
-    new_version_range = _new_version_range,
-    new_product = _new_product,
-    new_product_type = _new_product_type,
-    new_product_reference = _new_product_reference,
-    new_by_name_reference = _new_by_name_reference,
-    new_target_reference = _new_target_reference,
-    new_target_dependency = _new_target_dependency,
-    new_target = _new_target,
+    new_from_parsed_json = _new_from_parsed_json,
     new_library_type = _new_library_type,
+    new_platform = _new_platform,
+    new_product = _new_product,
+    new_product_reference = _new_product_reference,
+    new_product_type = _new_product_type,
+    new_target = _new_target,
+    new_target_dependency = _new_target_dependency,
+    new_target_reference = _new_target_reference,
+    new_version_range = _new_version_range,
 )

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -170,8 +170,12 @@ def _new_clang_settings_from_dump_json_list(dump_list):
     for setting in dump_list:
         if setting["tool"] != "c":
             continue
-        kind_map = setting["kind"]
-        define_map = kind_map["define"]
+        kind_map = setting.get("kind")
+        if kind_map == None:
+            continue
+        define_map = kind_map.get("define")
+        if define_map == None:
+            continue
         for (k, define) in define_map.items():
             defines.append(define)
 
@@ -186,8 +190,12 @@ def _new_swift_settings_from_dump_json_list(dump_list):
     for setting in dump_list:
         if setting["tool"] != "swift":
             continue
-        kind_map = setting["kind"]
-        define_map = kind_map["define"]
+        kind_map = setting.get("kind")
+        if kind_map == None:
+            continue
+        define_map = kind_map.get("define")
+        if define_map == None:
+            continue
         for (k, define) in define_map.items():
             defines.append(define)
 

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -176,7 +176,7 @@ def _new_clang_settings_from_dump_json_list(dump_list):
         define_map = kind_map.get("define")
         if define_map == None:
             continue
-        for (k, define) in define_map.items():
+        for define in define_map.values():
             defines.append(define)
 
     if len(defines) == 0:
@@ -196,7 +196,7 @@ def _new_swift_settings_from_dump_json_list(dump_list):
         define_map = kind_map.get("define")
         if define_map == None:
             continue
-        for (k, define) in define_map.items():
+        for define in define_map.values():
             defines.append(define)
 
     if len(defines) == 0:
@@ -604,6 +604,7 @@ pkginfos = struct(
     new_product = _new_product,
     new_product_reference = _new_product_reference,
     new_product_type = _new_product_type,
+    new_swift_settings = _new_swift_settings,
     new_target = _new_target,
     new_target_dependency = _new_target_dependency,
     new_target_reference = _new_target_reference,

--- a/swiftpkg/internal/repo_rules.bzl
+++ b/swiftpkg/internal/repo_rules.bzl
@@ -75,6 +75,13 @@ def _gen_build_files(repository_ctx, pkg_info):
     # Create Bazel declarations for the targets
     bld_files.append(swiftpkg_build_files.new_for_products(pkg_info, repo_name))
 
+    # # DEBUG BEGIN
+    # print("*** CHUCK repo_name: ", repo_name)
+    # print("*** CHUCK bld_files: ")
+    # for idx, item in enumerate(bld_files):
+    #     print("*** CHUCK", idx, ":", item)
+    # # DEBUG END
+
     # Write the build file
     root_bld_file = build_files.merge(*bld_files)
     build_files.write(repository_ctx, root_bld_file, pkg_info.path)

--- a/swiftpkg/internal/repo_rules.bzl
+++ b/swiftpkg/internal/repo_rules.bzl
@@ -75,13 +75,6 @@ def _gen_build_files(repository_ctx, pkg_info):
     # Create Bazel declarations for the targets
     bld_files.append(swiftpkg_build_files.new_for_products(pkg_info, repo_name))
 
-    # # DEBUG BEGIN
-    # print("*** CHUCK repo_name: ", repo_name)
-    # print("*** CHUCK bld_files: ")
-    # for idx, item in enumerate(bld_files):
-    #     print("*** CHUCK", idx, ":", item)
-    # # DEBUG END
-
     # Write the build file
     root_bld_file = build_files.merge(*bld_files)
     build_files.write(repository_ctx, root_bld_file, pkg_info.path)

--- a/swiftpkg/internal/repo_rules.bzl
+++ b/swiftpkg/internal/repo_rules.bzl
@@ -67,7 +67,7 @@ def _gen_build_files(repository_ctx, pkg_info):
     # Create Bazel declarations for the Swift package targets
     bld_files = []
     for target in pkg_info.targets:
-        bld_file = swiftpkg_build_files.new_for_target(pkg_ctx, target)
+        bld_file = swiftpkg_build_files.new_for_target(repository_ctx, pkg_ctx, target)
         if bld_file == None:
             continue
         bld_files.append(bld_file)

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -39,6 +39,8 @@ def _swift_target_build_file(pkg_ctx, target):
         "srcs": pkginfo_targets.srcs(target),
         "visibility": ["//visibility:public"],
     }
+    if target.swift_settings and len(target.swift_settings.defines) > 0:
+        attrs["defines"].extend(target.swift_settings.defines)
 
     # GH046: Support plugins.
     if lists.contains([target_types.library, target_types.regular], target.type):
@@ -82,17 +84,7 @@ def _swift_test_from_target(target, attrs):
 # MARK: - Clang Targets
 
 def _clang_target_build_file(repository_ctx, pkg_ctx, target):
-    # DEBUG BEGIN
-    print("*** CHUCK ========")
-    print("*** CHUCK target.name: ", target.name)
-
-    # DEBUG END
-
-    # srcs = pkginfo_targets.srcs(target)
-    # organized_files = clang_files.organize(srcs)
-
     target_path = paths.join(pkg_ctx.pkg_info.path, target.path)
-
     organized_files = clang_files.collect_files(
         repository_ctx,
         [target_path],

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -112,7 +112,9 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         attrs["srcs"] = organized_files.srcs
     if len(organized_files.hdrs) > 0:
         attrs["hdrs"] = organized_files.hdrs
-    if len(organized_files.includes) > 0:
+    if len(organized_files.public_includes) > 0:
+        attrs["includes"] = organized_files.public_includes
+    if len(organized_files.private_includes) > 0:
         # The `includes` attribute adds includes as -isystem which propagates
         # to cc_XXX that depend upon the library. Providing includes as -I only
         # provides the includes for this target.
@@ -122,7 +124,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             # Because this is an external repo, we need to prepend
             # external/<repo_name> to all of the include dirs
             "-I{}".format(paths.join("external", repo_name, inc))
-            for inc in organized_files.includes
+            for inc in organized_files.private_includes
         ]
 
     load_stmts = []

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -126,6 +126,8 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             "-I{}".format(paths.join("external", repo_name, inc))
             for inc in organized_files.private_includes
         ]
+    if target.clang_settings and len(target.clang_settings.defines) > 0:
+        attrs["defines"] = target.clang_settings.defines
 
     load_stmts = []
     decls = [

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -40,6 +40,9 @@ def _swift_target_build_file(repository_ctx, pkg_ctx, target):
         "visibility": ["//visibility:public"],
     }
 
+    # TODO(chuck): Consider adding support for custom build files for select repositories. Having
+    # trouble getting vapor application to link.
+
     # GH046: Support plugins.
 
     # The rules_swift code links in developer libraries if the rule is marked testonly.

--- a/swiftpkg/tests/pkginfos_tests.bzl
+++ b/swiftpkg/tests/pkginfos_tests.bzl
@@ -56,6 +56,9 @@ def _get_test(ctx):
                         ),
                     ),
                 ],
+                clang_settings = pkginfos.new_clang_settings(
+                    defines = ["__APPLE_USE_RFC_3542"],
+                ),
             ),
             pkginfos.new_target(
                 name = "MySwiftPackageTests",
@@ -167,7 +170,14 @@ _dump_manifest_json = """
 
       ],
       "settings" : [
-
+          {
+            "kind" : {
+              "define" : {
+                "_0" : "__APPLE_USE_RFC_3542"
+              }
+            },
+            "tool" : "c"
+          }
       ],
       "type" : "executable"
     },

--- a/swiftpkg/tests/pkginfos_tests.bzl
+++ b/swiftpkg/tests/pkginfos_tests.bzl
@@ -56,6 +56,12 @@ def _get_test(ctx):
                         ),
                     ),
                 ],
+                swift_settings = pkginfos.new_swift_settings(
+                    defines = ["COOL_SWIFT_DEFINE"],
+                ),
+                # This is very contrived. We would not expect clang settings on
+                # a Swift target. However, the JSON structure does not prevent
+                # it.
                 clang_settings = pkginfos.new_clang_settings(
                     defines = ["__APPLE_USE_RFC_3542"],
                 ),
@@ -170,6 +176,14 @@ _dump_manifest_json = """
 
       ],
       "settings" : [
+          {
+            "kind" : {
+              "define" : {
+                "_0" : "COOL_SWIFT_DEFINE"
+              }
+            },
+            "tool" : "swift"
+          },
           {
             "kind" : {
               "define" : {

--- a/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
@@ -121,7 +121,7 @@ def _swift_library_target_test(ctx):
     env = unittest.begin(ctx)
 
     target = pkginfo_targets.get(_pkg_info.targets, "SwiftLintFramework")
-    actual = swiftpkg_build_files.new_for_target(_pkg_ctx, target)
+    actual = swiftpkg_build_files.new_for_target(None, _pkg_ctx, target)
     expected = build_files.new(
         load_stmts = [swift_library_load_stmt],
         decls = [
@@ -153,7 +153,7 @@ def _swift_library_target_for_binary_test(ctx):
     # We create the swift_library in the target package. Then, we create the
     # executable when defining the product.
     target = pkginfo_targets.get(_pkg_info.targets, "swiftlint")
-    actual = swiftpkg_build_files.new_for_target(_pkg_ctx, target)
+    actual = swiftpkg_build_files.new_for_target(None, _pkg_ctx, target)
     expected = build_files.new(
         load_stmts = [swift_library_load_stmt],
         decls = [
@@ -185,7 +185,7 @@ def _swift_test_target_test(ctx):
     env = unittest.begin(ctx)
 
     target = pkginfo_targets.get(_pkg_info.targets, "SwiftLintFrameworkTests")
-    actual = swiftpkg_build_files.new_for_target(_pkg_ctx, target)
+    actual = swiftpkg_build_files.new_for_target(None, _pkg_ctx, target)
     expected = build_files.new(
         load_stmts = [swift_test_load_stmt],
         decls = [

--- a/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_for_old_style_pkg_tests.bzl
@@ -117,11 +117,22 @@ _pkg_ctx = pkg_ctxs.new(
     module_index_json = _module_index_json,
 )
 
+def new_stub_repository_ctx():
+    # buildifier: disable=unused-variable
+    def read(path):
+        return ""
+
+    return struct(
+        read = read,
+    )
+
+repository_ctx = new_stub_repository_ctx()
+
 def _swift_library_target_test(ctx):
     env = unittest.begin(ctx)
 
     target = pkginfo_targets.get(_pkg_info.targets, "SwiftLintFramework")
-    actual = swiftpkg_build_files.new_for_target(None, _pkg_ctx, target)
+    actual = swiftpkg_build_files.new_for_target(repository_ctx, _pkg_ctx, target)
     expected = build_files.new(
         load_stmts = [swift_library_load_stmt],
         decls = [
@@ -153,7 +164,7 @@ def _swift_library_target_for_binary_test(ctx):
     # We create the swift_library in the target package. Then, we create the
     # executable when defining the product.
     target = pkginfo_targets.get(_pkg_info.targets, "swiftlint")
-    actual = swiftpkg_build_files.new_for_target(None, _pkg_ctx, target)
+    actual = swiftpkg_build_files.new_for_target(repository_ctx, _pkg_ctx, target)
     expected = build_files.new(
         load_stmts = [swift_library_load_stmt],
         decls = [
@@ -185,7 +196,7 @@ def _swift_test_target_test(ctx):
     env = unittest.begin(ctx)
 
     target = pkginfo_targets.get(_pkg_info.targets, "SwiftLintFrameworkTests")
-    actual = swiftpkg_build_files.new_for_target(None, _pkg_ctx, target)
+    actual = swiftpkg_build_files.new_for_target(repository_ctx, _pkg_ctx, target)
     expected = build_files.new(
         load_stmts = [swift_test_load_stmt],
         decls = [


### PR DESCRIPTION
- Separate headers between public and private.
- Combine headers found by inspection with those in the modulemap.
- Add support for custom defines for Swift and clang.

Related to #50.