### PR TITLE
chore: upgrade `rules_swift` to 1.5

### DIFF
--- a/bazel_versions.bzl
+++ b/bazel_versions.bzl
@@ -5,5 +5,4 @@ CURRENT_BAZEL_VERSION = "//:.bazelversion"
 SUPPORTED_BAZEL_VERSIONS = [
     CURRENT_BAZEL_VERSION,
     "5.4.0",
-    "7.0.0-pre.20221212.2",
 ]

--- a/examples/http_archive_ext_deps/Sources/PrintStuff/BUILD.bazel
+++ b/examples/http_archive_ext_deps/Sources/PrintStuff/BUILD.bazel
@@ -3,7 +3,6 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 swift_binary(
     name = "PrintStuff",
     srcs = ["PrintStuff.swift"],
-    copts = ["-parse-as-library"],
     module_name = "PrintStuff",
     visibility = ["//visibility:public"],
     deps = [

--- a/examples/http_archive_ext_deps/Tests/MyDequeModuleTests/BUILD.bazel
+++ b/examples/http_archive_ext_deps/Tests/MyDequeModuleTests/BUILD.bazel
@@ -2,7 +2,10 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
     name = "MyDequeModuleTests",
-    srcs = ["CreateTests.swift"],
+    srcs = [
+        "CreateTests.swift",
+        "main.swift",
+    ],
     module_name = "MyDequeModuleTests",
     deps = ["//Sources/MyDequeModule"],
 )

--- a/examples/http_archive_ext_deps/Tests/MyDequeModuleTests/CreateTests.swift
+++ b/examples/http_archive_ext_deps/Tests/MyDequeModuleTests/CreateTests.swift
@@ -5,4 +5,8 @@ class CreateTests: XCTestCase {
     func test_MyDeques_colors() throws {
         XCTAssertEqual(MyDeques.colors.count, 3)
     }
+
+    static var allTests = [
+      ("test_MyDeques_colors", test_MyDeques_colors),
+    ]
 }

--- a/examples/http_archive_ext_deps/Tests/MyDequeModuleTests/main.swift
+++ b/examples/http_archive_ext_deps/Tests/MyDequeModuleTests/main.swift
@@ -1,0 +1,7 @@
+#if os(Linux)
+import XCTest
+
+XCTMain([
+    testCase(CreateTests.allTests),
+])
+#endif

--- a/examples/http_archive_ext_deps/WORKSPACE
+++ b/examples/http_archive_ext_deps/WORKSPACE
@@ -36,8 +36,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_swift",
-    sha256 = "51efdaf85e04e51174de76ef563f255451d5a5cd24c61ad902feeadafc7046d9",
-    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.2.0/rules_swift.1.2.0.tar.gz",
+    sha256 = "32f95dbe6a88eb298aaa790f05065434f32a662c65ec0a6aabdaf6881e4f169f",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.5.0/rules_swift.1.5.0.tar.gz",
 )
 
 load(

--- a/examples/pkg_manifest_minimal/Sources/MyExecutable/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/Sources/MyExecutable/BUILD.bazel
@@ -3,7 +3,6 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 swift_binary(
     name = "MyExecutable",
     srcs = ["MyExecutable.swift"],
-    copts = ["-parse-as-library"],
     module_name = "MyExecutable",
     visibility = ["//visibility:public"],
     deps = [

--- a/examples/pkg_manifest_minimal/Tests/MyLibraryTests/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/Tests/MyLibraryTests/BUILD.bazel
@@ -2,7 +2,10 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
     name = "MyLibraryTests",
-    srcs = ["MyLibraryTests.swift"],
+    srcs = [
+        "MyLibraryTests.swift",
+        "main.swift",
+    ],
     module_name = "MyLibraryTests",
     deps = ["//Sources/MyLibrary"],
 )

--- a/examples/pkg_manifest_minimal/Tests/MyLibraryTests/MyLibraryTests.swift
+++ b/examples/pkg_manifest_minimal/Tests/MyLibraryTests/MyLibraryTests.swift
@@ -5,4 +5,8 @@ final class MyLibraryTests: XCTestCase {
     func testExample() throws {
         XCTAssertEqual(World().name, "World")
     }
+
+    static var allTests = [
+      ("testExample", testExample),
+    ]
 }

--- a/examples/pkg_manifest_minimal/Tests/MyLibraryTests/main.swift
+++ b/examples/pkg_manifest_minimal/Tests/MyLibraryTests/main.swift
@@ -1,0 +1,7 @@
+#if os(Linux)
+import XCTest
+
+XCTMain([
+    testCase(MyLibraryTests.allTests),
+])
+#endif

--- a/examples/pkg_manifest_minimal/WORKSPACE
+++ b/examples/pkg_manifest_minimal/WORKSPACE
@@ -36,8 +36,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_swift",
-    sha256 = "51efdaf85e04e51174de76ef563f255451d5a5cd24c61ad902feeadafc7046d9",
-    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.2.0/rules_swift.1.2.0.tar.gz",
+    sha256 = "32f95dbe6a88eb298aaa790f05065434f32a662c65ec0a6aabdaf6881e4f169f",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.5.0/rules_swift.1.5.0.tar.gz",
 )
 
 load(

--- a/examples/pkg_manifest_minimal/module_index.json
+++ b/examples/pkg_manifest_minimal/module_index.json
@@ -53,12 +53,6 @@
   "SwiftFormatTests": [
     "@swiftpkg_swiftformat//:Tests_SwiftFormatTests"
   ],
-  "changelog_authors": [
-    "@swiftpkg_swift_argument_parser//:Tools_changelog-authors"
-  ],
-  "count_lines": [
-    "@swiftpkg_swift_argument_parser//:Examples_count-lines"
-  ],
   "generate_manual": [
     "@swiftpkg_swift_argument_parser//:Tools_generate-manual"
   ],

--- a/examples/vapor_example/Tests/AppTests/AppTests.swift
+++ b/examples/vapor_example/Tests/AppTests/AppTests.swift
@@ -12,4 +12,8 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.body.string, "Hello, Timmy!")
         })
     }
+
+    static var allTests = [
+      ("testHelloWorld", testHelloWorld),
+    ]
 }

--- a/examples/vapor_example/Tests/AppTests/BUILD.bazel
+++ b/examples/vapor_example/Tests/AppTests/BUILD.bazel
@@ -2,7 +2,10 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
     name = "AppTests",
-    srcs = ["AppTests.swift"],
+    srcs = [
+        "AppTests.swift",
+        "main.swift",
+    ],
     module_name = "AppTests",
     deps = [
         "//Sources/App",

--- a/examples/vapor_example/Tests/AppTests/main.swift
+++ b/examples/vapor_example/Tests/AppTests/main.swift
@@ -1,0 +1,7 @@
+#if os(Linux)
+import XCTest
+
+XCTMain([
+    testCase(AppTests.allTests),
+])
+#endif

--- a/examples/vapor_example/WORKSPACE
+++ b/examples/vapor_example/WORKSPACE
@@ -36,8 +36,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_swift",
-    sha256 = "51efdaf85e04e51174de76ef563f255451d5a5cd24c61ad902feeadafc7046d9",
-    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.2.0/rules_swift.1.2.0.tar.gz",
+    sha256 = "32f95dbe6a88eb298aaa790f05065434f32a662c65ec0a6aabdaf6881e4f169f",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.5.0/rules_swift.1.5.0.tar.gz",
 )
 
 load(

--- a/gazelle/internal/swift/file_info.go
+++ b/gazelle/internal/swift/file_info.go
@@ -21,10 +21,9 @@ type FileInfo struct {
 
 func NewFileInfoFromReader(rel, abs string, reader io.Reader) *FileInfo {
 	fi := FileInfo{
-		Rel: rel,
-		Abs: abs,
-		// TODO(chuck): FIX ME!
-		IsTest: testSuffixes.HasSuffix(rel),
+		Rel:    rel,
+		Abs:    abs,
+		IsTest: testSuffixes.HasSuffix(rel) || TestDirSuffixes.IsUnderDirWithSuffix(rel),
 		// There are several ways to detect a main.
 		// 1. A file named "main.swift"
 		// 2. @main annotation

--- a/gazelle/internal/swift/file_info.go
+++ b/gazelle/internal/swift/file_info.go
@@ -21,8 +21,9 @@ type FileInfo struct {
 
 func NewFileInfoFromReader(rel, abs string, reader io.Reader) *FileInfo {
 	fi := FileInfo{
-		Rel:    rel,
-		Abs:    abs,
+		Rel: rel,
+		Abs: abs,
+		// TODO(chuck): FIX ME!
 		IsTest: testSuffixes.HasSuffix(rel),
 		// There are several ways to detect a main.
 		// 1. A file named "main.swift"
@@ -109,3 +110,27 @@ func (fs fileSuffixes) HasSuffix(path string) bool {
 }
 
 var testSuffixes = fileSuffixes{"Tests.swift", "Test.swift"}
+
+type DirSuffixes []string
+
+func (ds DirSuffixes) HasSuffix(path string) bool {
+	for _, suffix := range ds {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (ds DirSuffixes) IsUnderDirWithSuffix(path string) bool {
+	if path == "." || path == "" || path == "/" {
+		return false
+	}
+	dir := filepath.Dir(path)
+	if ds.HasSuffix(dir) {
+		return true
+	}
+	return ds.IsUnderDirWithSuffix(dir)
+}
+
+var TestDirSuffixes = DirSuffixes{"Tests", "Test"}

--- a/gazelle/internal/swift/file_info_test.go
+++ b/gazelle/internal/swift/file_info_test.go
@@ -48,6 +48,20 @@ func TestNewFileInfoFromSrc(t *testing.T) {
 	})
 }
 
+func TestDirSuffixes(t *testing.T) {
+	actual := swift.TestDirSuffixes.IsUnderDirWithSuffix("Sources/Foo/Bar.swift")
+	assert.False(t, actual)
+
+	actual = swift.TestDirSuffixes.IsUnderDirWithSuffix("Tests/FooTests/Bar.swift")
+	assert.True(t, actual)
+
+	actual = swift.TestDirSuffixes.IsUnderDirWithSuffix("Tests/FooTests/Chicken/Bar.swift")
+	assert.True(t, actual)
+
+	actual = swift.TestDirSuffixes.IsUnderDirWithSuffix("Tests/Bar.swift")
+	assert.True(t, actual)
+}
+
 const mainFnWithoutImports = `
 @main
 public struct Hello {

--- a/gazelle/internal/swift/file_info_test.go
+++ b/gazelle/internal/swift/file_info_test.go
@@ -46,6 +46,19 @@ func TestNewFileInfoFromSrc(t *testing.T) {
 		}
 		assert.Equal(t, expected, actual)
 	})
+	t.Run("main under test directory", func(t *testing.T) {
+		rel := "FooTests/main.swift"
+		abs := filepath.Join("Tests", rel)
+		actual := swift.NewFileInfoFromSrc(rel, abs, mainForTest)
+		expected := &swift.FileInfo{
+			Rel:          rel,
+			Abs:          abs,
+			Imports:      []string{"XCTest"},
+			IsTest:       true,
+			ContainsMain: true,
+		}
+		assert.Equal(t, expected, actual)
+	})
 }
 
 func TestDirSuffixes(t *testing.T) {
@@ -106,4 +119,14 @@ import XCTest
 
 class DateISOTests: XCTestCase {
 }
+`
+
+const mainForTest = `
+#if os(Linux)
+import XCTest
+
+XCTMain([
+    testCase(AppTests.allTests),
+])
+#endif
 `

--- a/gazelle/internal/swift/rules_common.go
+++ b/gazelle/internal/swift/rules_common.go
@@ -29,12 +29,6 @@ func rulesForBinaryModule(
 	r := rule.NewRule(BinaryRuleKind, moduleName)
 	setCommonSwiftAttrs(r, moduleName, srcs, swiftImports)
 	setVisibilityAttr(r, shouldSetVis, []string{"//visibility:public"})
-	// Fixed https://github.com/bazelbuild/rules_swift/issues/913
-	// // Swift treats single file binary compilations differently. We need to tell Swift to compile
-	// // the single file as a library.
-	// if len(srcs) == 1 && srcs[0] != "main.swift" {
-	// 	r.SetAttr("copts", []string{"-parse-as-library"})
-	// }
 	return []*rule.Rule{r}
 }
 

--- a/gazelle/internal/swift/rules_common.go
+++ b/gazelle/internal/swift/rules_common.go
@@ -29,11 +29,12 @@ func rulesForBinaryModule(
 	r := rule.NewRule(BinaryRuleKind, moduleName)
 	setCommonSwiftAttrs(r, moduleName, srcs, swiftImports)
 	setVisibilityAttr(r, shouldSetVis, []string{"//visibility:public"})
-	// Swift treats single file binary compilations differently. We need to tell Swift to compile
-	// the single file as a library.
-	if len(srcs) == 1 && srcs[0] != "main.swift" {
-		r.SetAttr("copts", []string{"-parse-as-library"})
-	}
+	// Fixed https://github.com/bazelbuild/rules_swift/issues/913
+	// // Swift treats single file binary compilations differently. We need to tell Swift to compile
+	// // the single file as a library.
+	// if len(srcs) == 1 && srcs[0] != "main.swift" {
+	// 	r.SetAttr("copts", []string{"-parse-as-library"})
+	// }
 	return []*rule.Rule{r}
 }
 


### PR DESCRIPTION
- Add support for `main.swift` in test packages.
- Add missing `main.swift` to `swift_test` for Linux.
- Remove 7.0-pre from supported Bazel versions to speed up CI.

Closes #89.