### PR TITLE
chore: reduce the number of integration test permutations

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -45,9 +45,9 @@ def swift_bazel_dependencies():
     maybe(
         http_archive,
         name = "cgrindel_bazel_starlib",
-        sha256 = "2b5031fd24ccc0bddcccd18c61d50c41970ad9757f15690ce6874935f298b05b",
-        strip_prefix = "bazel-starlib-0.10.3",
+        sha256 = "3f04ca2e3bef99563c6d96728b0a09f8484bc3c61ca804d29f67e86e6043c038",
+        strip_prefix = "bazel-starlib-0.11.0",
         urls = [
-            "http://github.com/cgrindel/bazel-starlib/archive/v0.10.3.tar.gz",
+            "http://github.com/cgrindel/bazel-starlib/archive/v0.11.0.tar.gz",
         ],
     )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,6 +1,9 @@
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "lists")
 load(
     "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "bazel_integration_test",
     "bazel_integration_tests",
     "integration_test_utils",
 )
@@ -14,19 +17,26 @@ bzlformat_pkg(name = "bzlformat")
 # repository.
 # gazelle:exclude **
 
-_all_os_test_examples = [
+_all_os_all_bazel_versions_test_examples = [
     "http_archive_ext_deps",
     "pkg_manifest_minimal",
+]
+
+_all_os_single_bazel_version_test_examples = [
     "vapor_example",
 ]
 
-_macos_test_examples = [
+_macos_single_bazel_version_test_examples = [
     "ios_sim",
 ]
 
-_linux_test_examples = []
+_linux_single_bazel_version_test_examples = []
 
-_all_examples = _all_os_test_examples + _macos_test_examples + _linux_test_examples
+_all_single_bazel_version_test_examples = _all_os_single_bazel_version_test_examples + \
+                                          _macos_single_bazel_version_test_examples + \
+                                          _linux_single_bazel_version_test_examples
+
+# _all_examples = _all_os_all_bazel_versions_test_examples + _macos_single_bazel_version_test_examples + _linux_single_bazel_version_test_examples
 
 sh_binary(
     name = "test_runner",
@@ -53,13 +63,34 @@ sh_binary(
         ],
         workspace_path = example,
     )
-    for example in _all_os_test_examples
+    for example in _all_os_all_bazel_versions_test_examples
 ]
 
 [
-    bazel_integration_tests(
-        name = example + "_test",
-        bazel_versions = SUPPORTED_BAZEL_VERSIONS,
+    bazel_integration_test(
+        # name = example + "_test",
+        name = integration_test_utils.bazel_integration_test_name(
+            example + "_test",
+            CURRENT_BAZEL_VERSION,
+        ),
+        bazel_version = CURRENT_BAZEL_VERSION,
+        test_runner = ":test_runner",
+        workspace_files = integration_test_utils.glob_workspace_files(example) + [
+            "//:local_repository_files",
+        ],
+        workspace_path = example,
+    )
+    for example in _all_os_single_bazel_version_test_examples
+]
+
+[
+    bazel_integration_test(
+        # name = example + "_test",
+        name = integration_test_utils.bazel_integration_test_name(
+            example + "_test",
+            CURRENT_BAZEL_VERSION,
+        ),
+        bazel_version = CURRENT_BAZEL_VERSION,
         target_compatible_with = ["@platforms//os:macos"],
         test_runner = ":test_runner",
         workspace_files = integration_test_utils.glob_workspace_files(example) + [
@@ -67,13 +98,17 @@ sh_binary(
         ],
         workspace_path = example,
     )
-    for example in _macos_test_examples
+    for example in _macos_single_bazel_version_test_examples
 ]
 
 [
-    bazel_integration_tests(
-        name = example + "_test",
-        bazel_versions = SUPPORTED_BAZEL_VERSIONS,
+    bazel_integration_test(
+        # name = example + "_test",
+        name = integration_test_utils.bazel_integration_test_name(
+            example + "_test",
+            CURRENT_BAZEL_VERSION,
+        ),
+        bazel_version = CURRENT_BAZEL_VERSION,
         target_compatible_with = ["@platforms//os:linux"],
         test_runner = ":test_runner",
         workspace_files = integration_test_utils.glob_workspace_files(example) + [
@@ -81,28 +116,45 @@ sh_binary(
         ],
         workspace_path = example,
     )
-    for example in _linux_test_examples
+    for example in _linux_single_bazel_version_test_examples
 ]
 
 # MARK: - Test Suites
 
-_test_base_names = [
-    example + "_test"
-    for example in _all_examples
-]
+# _test_base_names = [
+#     example + "_test"
+#     for example in _all_examples
+# ]
 
-_smoke_test_names = [
+_smoke_test_examples = _all_os_all_bazel_versions_test_examples + \
+                       _all_single_bazel_version_test_examples
+
+_smoke_test_names = sorted([
     integration_test_utils.bazel_integration_test_name(
-        test_base_name,
+        example + "_test",
         CURRENT_BAZEL_VERSION,
     )
-    for test_base_name in _test_base_names
-]
+    for example in _smoke_test_examples
+])
 
-_all_test_names = test_utils.integration_test_names(
-    base_names = _test_base_names,
-    versions = SUPPORTED_BAZEL_VERSIONS,
-)
+_all_os_all_bazel_versions_test_names = lists.flatten([
+    test_utils.integration_test_names(
+        base_names = [
+            example + "_test"
+            for example in _all_os_all_bazel_versions_test_examples
+        ],
+        versions = SUPPORTED_BAZEL_VERSIONS,
+    ),
+])
+
+# _all_test_names = test_utils.integration_test_names(
+#     base_names = _test_base_names,
+#     versions = SUPPORTED_BAZEL_VERSIONS,
+# )
+
+_all_test_names = sorted(sets.to_list(
+    sets.make(_all_os_all_bazel_versions_test_names + _smoke_test_names),
+))
 
 test_suite(
     name = "smoke_integration_tests",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -32,11 +32,10 @@ _macos_single_bazel_version_test_examples = [
 
 _linux_single_bazel_version_test_examples = []
 
-_all_single_bazel_version_test_examples = _all_os_single_bazel_version_test_examples + \
-                                          _macos_single_bazel_version_test_examples + \
-                                          _linux_single_bazel_version_test_examples
-
-# _all_examples = _all_os_all_bazel_versions_test_examples + _macos_single_bazel_version_test_examples + _linux_single_bazel_version_test_examples
+_all_single_bazel_version_test_examples = \
+    _all_os_single_bazel_version_test_examples + \
+    _macos_single_bazel_version_test_examples + \
+    _linux_single_bazel_version_test_examples
 
 sh_binary(
     name = "test_runner",
@@ -68,7 +67,6 @@ sh_binary(
 
 [
     bazel_integration_test(
-        # name = example + "_test",
         name = integration_test_utils.bazel_integration_test_name(
             example + "_test",
             CURRENT_BAZEL_VERSION,
@@ -85,7 +83,6 @@ sh_binary(
 
 [
     bazel_integration_test(
-        # name = example + "_test",
         name = integration_test_utils.bazel_integration_test_name(
             example + "_test",
             CURRENT_BAZEL_VERSION,
@@ -103,7 +100,6 @@ sh_binary(
 
 [
     bazel_integration_test(
-        # name = example + "_test",
         name = integration_test_utils.bazel_integration_test_name(
             example + "_test",
             CURRENT_BAZEL_VERSION,
@@ -120,11 +116,6 @@ sh_binary(
 ]
 
 # MARK: - Test Suites
-
-# _test_base_names = [
-#     example + "_test"
-#     for example in _all_examples
-# ]
 
 _smoke_test_examples = _all_os_all_bazel_versions_test_examples + \
                        _all_single_bazel_version_test_examples
@@ -146,11 +137,6 @@ _all_os_all_bazel_versions_test_names = lists.flatten([
         versions = SUPPORTED_BAZEL_VERSIONS,
     ),
 ])
-
-# _all_test_names = test_utils.integration_test_names(
-#     base_names = _test_base_names,
-#     versions = SUPPORTED_BAZEL_VERSIONS,
-# )
 
 _all_test_names = sorted(sets.to_list(
     sets.make(_all_os_all_bazel_versions_test_names + _smoke_test_names),


### PR DESCRIPTION
Goal: Speed up CI while ensuring that each example is executed at least once under the current Bazel version.