### PR TITLE
feat: introduce `swift_update_packages` macro

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -14,6 +14,9 @@ markdown_pkg(name = "markdown")
 # MARK: - Documentation Declarations
 
 _DOC_WITH_SYMBOLS = {
+    "macros": [
+        "swift_update_packages",
+    ],
     "repository_rules": [
         "local_swift_package",
         "swift_package",
@@ -46,6 +49,19 @@ products and targets available as Bazel targets.
 """,
     ],
     symbols = _DOC_WITH_SYMBOLS["repository_rules"],
+)
+
+write_header(
+    name = "macros_overview_header",
+    header_content = [
+        "# Macros",
+        "",
+        """
+The macros described below are used to define Gazelle targets to aid in the \
+generation and maintenance of Swift package dependencies.
+""",
+    ],
+    symbols = _DOC_WITH_SYMBOLS["macros"],
 )
 
 doc_for_provs(doc_provs = _ALL_DOC_PROVIDERS)

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,7 +1,6 @@
 load(
     "@cgrindel_bazel_starlib//bazeldoc:defs.bzl",
     "doc_for_provs",
-    "write_header",
     doc_providers = "providers",
 )
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
@@ -14,13 +13,14 @@ markdown_pkg(name = "markdown")
 # MARK: - Documentation Declarations
 
 _DOC_WITH_SYMBOLS = {
-    "macros": [
-        "swift_update_packages",
-    ],
-    "repository_rules": [
-        "local_swift_package",
-        "swift_package",
-    ],
+    # GH143: Enable once bazel-gazelle deps are fixed.
+    # "macros": [
+    #     "swift_update_packages",
+    # ],
+    # "repository_rules": [
+    #     "local_swift_package",
+    #     "swift_package",
+    # ],
 }
 
 _ALL_DOC_PROVIDERS = [
@@ -38,30 +38,32 @@ _ALL_DOC_PROVIDERS = [
 
 # MARK: - Headers
 
-write_header(
-    name = "repository_rules_overview_header",
-    header_content = [
-        "# Repository Rules",
-        "",
-        """
-The rules described below are used to build Swift packages and make their 
-products and targets available as Bazel targets.
-""",
-    ],
-    symbols = _DOC_WITH_SYMBOLS["repository_rules"],
-)
+# GH143: Enable once bazel-gazelle deps are fixed.
+# write_header(
+#     name = "repository_rules_overview_header",
+#     header_content = [
+#         "# Repository Rules",
+#         "",
+#         """
+# The rules described below are used to build Swift packages and make their
+# products and targets available as Bazel targets.
+# """,
+#     ],
+#     symbols = _DOC_WITH_SYMBOLS["repository_rules"],
+# )
 
-write_header(
-    name = "macros_overview_header",
-    header_content = [
-        "# Macros",
-        "",
-        """
-The macros described below are used to define Gazelle targets to aid in the \
-generation and maintenance of Swift package dependencies.
-""",
-    ],
-    symbols = _DOC_WITH_SYMBOLS["macros"],
-)
+# GH143: Enable once bazel-gazelle deps are fixed.
+# write_header(
+#     name = "macros_overview_header",
+#     header_content = [
+#         "# Macros",
+#         "",
+#         """
+# The macros described below are used to define Gazelle targets to aid in the \
+# generation and maintenance of Swift package dependencies.
+# """,
+#     ],
+#     symbols = _DOC_WITH_SYMBOLS["macros"],
+# )
 
 doc_for_provs(doc_provs = _ALL_DOC_PROVIDERS)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,7 @@
 * [Does this replace rules\_spm ?](https://github.com/cgrindel/rules_spm/)
 * [Can I migrate from rules\_spm to swift\_bazel ?](https://github.com/cgrindel/rules_spm/)
 * [Can I just manage my external Swift packages and not generate Bazel build files for my project?](#can-i-just-manage-my-external-swift-packages-and-not-generate-bazel-build-files-for-my-project)
-* [After running //:swift\_update\_repos , I see a \.build directory\. What is it? Do I need it?](#after-running-swift_update_repos-i-see-a-build-directory-what-is-it-do-i-need-it)
+* [After running //:swift\_update\_pkgs , I see a \.build directory\. What is it? Do I need it?](#after-running-swift_update_pkgs-i-see-a-build-directory-what-is-it-do-i-need-it)
 * [Does the Gazelle plugin run Swift package manager with every execution?](#does-the-gazelle-plugin-run-swift-package-manager-with-every-execution)
 <!-- MARKDOWN TOC: END -->
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,9 +67,9 @@ on the roadmap.
 
 Yes. Just omit the `//:update_build_files` target that is mentioned in the [quickstart].
 
-## After running `//:swift_update_repos`, I see a `.build` directory. What is it? Do I need it?
+## After running `//:swift_update_pkgs`, I see a `.build` directory. What is it? Do I need it?
 
-The `//:swift_update_repos` target runs the Gazelle plugin in `update-repos` mode. This mode
+The `//:swift_update_pkgs` target runs the Gazelle plugin in `update-repos` mode. This mode
 resolves the external dependencies listed in your `Package.swift` by running Swift package manager
 commands.  These commands result in a `.build` directory being created. The directory is a side
 effect of running the Swift package manager commands. It can be ignored and should not be checked

--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -2,11 +2,12 @@ load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -29,14 +30,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/interesting_deps/set_up_clean_test
+++ b/examples/interesting_deps/set_up_clean_test
@@ -22,11 +22,12 @@ load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -49,14 +50,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/ios_sim/BUILD.bazel
+++ b/examples/ios_sim/BUILD.bazel
@@ -1,11 +1,12 @@
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -28,14 +29,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/ios_sim/set_up_clean_test
+++ b/examples/ios_sim/set_up_clean_test
@@ -24,11 +24,12 @@ cat > "${script_dir}/BUILD.bazel"  <<-EOF
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -51,14 +52,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/objc_code/BUILD.bazel
+++ b/examples/objc_code/BUILD.bazel
@@ -2,11 +2,12 @@ load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -29,14 +30,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/objc_code/set_up_clean_test
+++ b/examples/objc_code/set_up_clean_test
@@ -24,11 +24,12 @@ cat > "${script_dir}/BUILD.bazel"  <<-EOF
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -51,14 +52,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/pkg_manifest_minimal/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
@@ -28,25 +29,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-_UPDATE_REPOS_ARGS = [
-    "-from_file=Package.swift",
-    "-to_macro=swift_deps.bzl%swift_dependencies",
-    "-prune",
-]
-
-gazelle(
+swift_update_packages(
     name = "swift_update_repos",
-    args = _UPDATE_REPOS_ARGS,
-    command = "update-repos",
-    gazelle = ":gazelle_bin",
-)
-
-gazelle(
-    name = "swift_update_repos_to_latest",
-    args = _UPDATE_REPOS_ARGS + [
-        "-swift_update_packages_to_latest",
-    ],
-    command = "update-repos",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/pkg_manifest_minimal/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/BUILD.bazel
@@ -6,7 +6,7 @@ load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -30,7 +30,7 @@ gazelle(
 )
 
 swift_update_packages(
-    name = "swift_update_repos",
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/pkg_manifest_minimal/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/BUILD.bazel
@@ -28,12 +28,23 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
+_UPDATE_REPOS_ARGS = [
+    "-from_file=Package.swift",
+    "-to_macro=swift_deps.bzl%swift_dependencies",
+    "-prune",
+]
+
 gazelle(
     name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
+    args = _UPDATE_REPOS_ARGS,
+    command = "update-repos",
+    gazelle = ":gazelle_bin",
+)
+
+gazelle(
+    name = "swift_update_repos_to_latest",
+    args = _UPDATE_REPOS_ARGS + [
+        "-swift_update_packages_to_latest",
     ],
     command = "update-repos",
     gazelle = ":gazelle_bin",

--- a/examples/pkg_manifest_minimal/Package.resolved
+++ b/examples/pkg_manifest_minimal/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "da637c398c5d08896521b737f2868ddc2e7996ae",
-        "version" : "0.50.6"
+        "revision" : "34cd9dd87b78048ce0d623a9153f9bf260ad6590",
+        "version" : "0.50.7"
       }
     }
   ],

--- a/examples/pkg_manifest_minimal/set_up_clean_test
+++ b/examples/pkg_manifest_minimal/set_up_clean_test
@@ -24,11 +24,12 @@ cat > "${script_dir}/BUILD.bazel"  <<-EOF
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -51,14 +52,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/vapor_example/BUILD.bazel
+++ b/examples/vapor_example/BUILD.bazel
@@ -1,11 +1,12 @@
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -28,14 +29,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/vapor_example/set_up_clean_test
+++ b/examples/vapor_example/set_up_clean_test
@@ -24,11 +24,12 @@ cat > "${script_dir}/BUILD.bazel"  <<-EOF
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -51,14 +52,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/xcmetrics_example/BUILD.bazel
+++ b/examples/xcmetrics_example/BUILD.bazel
@@ -2,11 +2,12 @@ load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -29,14 +30,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/examples/xcmetrics_example/set_up_clean_test
+++ b/examples/xcmetrics_example/set_up_clean_test
@@ -25,11 +25,12 @@ load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@cgrindel_bazel_starlib//bzltidy:defs.bzl", "tidy")
+load("@cgrindel_swift_bazel//swiftpkg:defs.bzl", "swift_update_packages")
 
 tidy(
     name = "tidy",
     targets = [
-        ":swift_update_repos",
+        ":swift_update_pkgs",
         ":update_build_files",
     ],
 )
@@ -52,14 +53,8 @@ gazelle(
     gazelle = ":gazelle_bin",
 )
 
-gazelle(
-    name = "swift_update_repos",
-    args = [
-        "-from_file=Package.swift",
-        "-to_macro=swift_deps.bzl%swift_dependencies",
-        "-prune",
-    ],
-    command = "update-repos",
+swift_update_packages(
+    name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
 )
 

--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -22,6 +22,15 @@ func (*swiftLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) 
 		"the location of the dependency index JSON file",
 	)
 
+	switch cmd {
+	case "update-repos":
+		fs.BoolVar(
+			&sc.UpdatePkgsToLatest,
+			"swift_update_packages_to_latest",
+			false,
+			"Determines whether to update the Swift packages to their latest eligible version.")
+	}
+
 	// Store the config for later steps
 	swiftcfg.SetSwiftConfig(c, sc)
 }

--- a/gazelle/internal/swiftbin/swift_bin.go
+++ b/gazelle/internal/swiftbin/swift_bin.go
@@ -3,7 +3,6 @@ package swiftbin
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os/exec"
 )
 
@@ -73,10 +72,6 @@ func (sb *SwiftBin) ResolvePackage(dir string, updateToLatest bool) error {
 		pkgCmd = "resolve"
 	}
 	args := []string{"package", pkgCmd}
-	// DEBUG BEGIN
-	log.Printf("*** CHUCK:  updateToLatest: %+#v", updateToLatest)
-	log.Printf("*** CHUCK:  args: %+#v", args)
-	// DEBUG END
 	cmd := exec.Command(sb.BinPath, args...)
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/gazelle/internal/swiftbin/swift_bin.go
+++ b/gazelle/internal/swiftbin/swift_bin.go
@@ -64,8 +64,14 @@ func (sb *SwiftBin) DescribePackage(dir string) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
-func (sb *SwiftBin) ResolvePackage(dir string) error {
-	args := []string{"package", "resolve"}
+func (sb *SwiftBin) ResolvePackage(dir string, updateToLatest bool) error {
+	var pkgCmd string
+	if updateToLatest {
+		pkgCmd = "update"
+	} else {
+		pkgCmd = "resolve"
+	}
+	args := []string{"package", pkgCmd}
 	cmd := exec.Command(sb.BinPath, args...)
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/gazelle/internal/swiftbin/swift_bin.go
+++ b/gazelle/internal/swiftbin/swift_bin.go
@@ -3,6 +3,7 @@ package swiftbin
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os/exec"
 )
 
@@ -72,6 +73,10 @@ func (sb *SwiftBin) ResolvePackage(dir string, updateToLatest bool) error {
 		pkgCmd = "resolve"
 	}
 	args := []string{"package", pkgCmd}
+	// DEBUG BEGIN
+	log.Printf("*** CHUCK:  updateToLatest: %+#v", updateToLatest)
+	log.Printf("*** CHUCK:  args: %+#v", args)
+	// DEBUG END
 	cmd := exec.Command(sb.BinPath, args...)
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/gazelle/internal/swiftbin/swift_bin_test.go
+++ b/gazelle/internal/swiftbin/swift_bin_test.go
@@ -72,10 +72,14 @@ func TestSwiftBin(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Resolve the package
-		err = sb.ResolvePackage(dir)
+		err = sb.ResolvePackage(dir, false)
 		assert.NoError(t, err)
 		resolvedPkgPath := filepath.Join(dir, "Package.resolved")
 		assert.FileExists(t, resolvedPkgPath)
+
+		// Resolve the package to their latest eligible version
+		err = sb.ResolvePackage(dir, true)
+		assert.NoError(t, err)
 	})
 }
 

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -21,6 +21,7 @@ type SwiftConfig struct {
 	DependencyIndex      *swift.DependencyIndex
 	DependencyIndexPath  string
 	PackageInfo          *swiftpkg.PackageInfo
+	UpdatePkgsToLatest   bool
 }
 
 func NewSwiftConfig() *SwiftConfig {
@@ -51,7 +52,6 @@ func (sc *SwiftConfig) GenerateRulesMode(args language.GenerateArgs) GenerateRul
 }
 
 func (sc *SwiftConfig) LoadDependencyIndex() error {
-	// If the file does not exist, do not fail. Just exit.
 	if sc.DependencyIndexPath == "" {
 		return nil
 	}

--- a/gazelle/update_repos.go
+++ b/gazelle/update_repos.go
@@ -43,7 +43,7 @@ func importReposFromPackageManifest(args language.ImportReposArgs) language.Impo
 
 	// Ensure that we have resolved and fetched the Swift package dependencies
 	pkgDir := filepath.Dir(args.Path)
-	if err := sb.ResolvePackage(pkgDir); err != nil {
+	if err := sb.ResolvePackage(pkgDir, sc.UpdatePkgsToLatest); err != nil {
 		result.Error = err
 		return result
 	}

--- a/swiftpkg/BUILD.bazel
+++ b/swiftpkg/BUILD.bazel
@@ -11,6 +11,7 @@ bzl_library(
     deps = [
         "//swiftpkg/internal:local_swift_package",
         "//swiftpkg/internal:swift_package",
+        "//swiftpkg/internal:swift_update_packages",
     ],
 )
 

--- a/swiftpkg/defs.bzl
+++ b/swiftpkg/defs.bzl
@@ -2,6 +2,11 @@
 
 load("//swiftpkg/internal:local_swift_package.bzl", _local_swift_package = "local_swift_package")
 load("//swiftpkg/internal:swift_package.bzl", _swift_package = "swift_package")
+load("//swiftpkg/internal:swift_update_packages.bzl", _swift_update_packages = "swift_update_packages")
 
+# Repository rules
 swift_package = _swift_package
 local_swift_package = _local_swift_package
+
+# Gazelle macros
+swift_update_packages = _swift_update_packages

--- a/swiftpkg/internal/BUILD.bazel
+++ b/swiftpkg/internal/BUILD.bazel
@@ -191,6 +191,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "swift_update_packages",
+    srcs = ["swift_update_packages.bzl"],
+    visibility = ["//swiftpkg:__subpackages__"],
+    deps = ["@bazel_gazelle//:def"],
+)
+
+bzl_library(
     name = "validations",
     srcs = ["validations.bzl"],
     visibility = ["//swiftpkg:__subpackages__"],

--- a/swiftpkg/internal/BUILD.bazel
+++ b/swiftpkg/internal/BUILD.bazel
@@ -173,6 +173,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "swift_update_packages",
+    srcs = ["swift_update_packages.bzl"],
+    visibility = ["//swiftpkg:__subpackages__"],
+    deps = ["@bazel_gazelle//:def"],
+)
+
+bzl_library(
     name = "bazel_repo_names",
     srcs = ["bazel_repo_names.bzl"],
     visibility = ["//swiftpkg:__subpackages__"],
@@ -188,13 +195,6 @@ bzl_library(
     name = "starlark_codegen",
     srcs = ["starlark_codegen.bzl"],
     visibility = ["//swiftpkg:__subpackages__"],
-)
-
-bzl_library(
-    name = "swift_update_packages",
-    srcs = ["swift_update_packages.bzl"],
-    visibility = ["//swiftpkg:__subpackages__"],
-    deps = ["@bazel_gazelle//:def"],
 )
 
 bzl_library(

--- a/swiftpkg/internal/swift_update_packages.bzl
+++ b/swiftpkg/internal/swift_update_packages.bzl
@@ -1,3 +1,5 @@
+"""Defines the `swift_update_packages` macro."""
+
 load("@bazel_gazelle//:def.bzl", _gazelle = "gazelle")
 
 def swift_update_packages(

--- a/swiftpkg/internal/swift_update_packages.bzl
+++ b/swiftpkg/internal/swift_update_packages.bzl
@@ -1,0 +1,49 @@
+load("@bazel_gazelle//:def.bzl", _gazelle = "gazelle")
+
+def swift_update_packages(
+        name,
+        gazelle,
+        package_manifest = "Package.swift",
+        swift_deps = "swift_deps.bzl",
+        swift_deps_fn = "swift_dependencies"):
+    """Defines gazelle update-repos targets that are used to resolve and update \
+    Swift package dependencies.
+
+    Args:
+        name: The name of the `resolve` target as a `string`. The target name
+            for the `update` target is derived from this value by appending
+            `_to_latest`.
+        gazelle: The label to `gazelle_binary` that includes the `swift_bazel`
+            Gazelle extension.
+        package_manifest: Optional. The name of the Swift package manifest file
+            as a `string`.
+        swift_deps: Optional. The name of the Starlark file that should be
+            updated with the Swift package dependencies as a `string`.
+        swift_deps_fn: Optional. The name of the Starlark function in the
+            `swift_deps` file that should be updated with the Swift package
+            dependencies as a `string`.
+    """
+    _SWIFT_UPDATE_REPOS_ARGS = [
+        "-from_file={}".format(package_manifest),
+        "-to_macro={swift_deps}%{swift_deps_fn}".format(
+            swift_deps = swift_deps,
+            swift_deps_fn = swift_deps_fn,
+        ),
+        "-prune",
+    ]
+
+    _gazelle(
+        name = name,
+        args = _SWIFT_UPDATE_REPOS_ARGS,
+        command = "update-repos",
+        gazelle = gazelle,
+    )
+
+    _gazelle(
+        name = name + "_to_latest",
+        args = _SWIFT_UPDATE_REPOS_ARGS + [
+            "-swift_update_packages_to_latest",
+        ],
+        command = "update-repos",
+        gazelle = gazelle,
+    )


### PR DESCRIPTION
- Add `swift_update_packages_to_latest` flag to Gazelle extension. When enabled, it runs `swift package update` instead of `swift package resolve` during `update-repos`.
- Introduce `swift_update_packages` macro to define variants of the `gazelle` declaration for `update-repos`. One performs the resolve and the other the update.

Closes #137.