### PR TITLE
fix: implement fixes from `firebase` example implementation

### DIFF
--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -54,11 +54,16 @@ def _is_public_modulemap(path):
     return basename == "module.modulemap"
 
 def _get_hdr_paths_from_modulemap(repository_ctx, modulemap_path, module_name):
-    """Retrieves the list of headers declared in the specified modulemap file.
+    """Retrieves the list of headers declared in the specified modulemap file \
+    for the specified module.
+
+    If the specified module is not found, all of the headers from the top-level
+    modules are returned.
 
     Args:
         repository_ctx: A `repository_ctx` instance.
         modulemap_path: A path `string` to the `module.modulemap` file.
+        module_name: The name of the module.
 
     Returns:
         A `list` of path `string` values.

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -177,6 +177,9 @@ def _collect_files(
                 sets.insert(hdrs_set, src)
         srcs_set = sets.difference(srcs_set, hdrs_set)
 
+    # TODO(chuck): Move the augmentation of the public_includes here from
+    # swiftpkg_build_files.
+
     # If public includes were specified, then use them. Otherwise, add every
     # directory that holds a public header file
     if len(public_includes) == 0:

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -96,6 +96,25 @@ def _get_hdr_paths_from_modulemap(repository_ctx, modulemap_path, module_name):
 
     return hdrs
 
+def _is_under_path(path, parent):
+    """Determines whether a path is under a another path.
+
+    Args:
+        path: The path to be evaluated as a `string`.
+        parent: The parent path as a `string`.
+
+    Returns:
+        A `bool` representing whether the path is under the parent path.
+    """
+    path = path.removesuffix("/")
+    parent = parent.removesuffix("/")
+    if path == parent:
+        return True
+    parent_prefix = parent if parent.endswith("/") else parent + "/"
+    if path.startswith(parent_prefix):
+        return True
+    return False
+
 def _relativize(path, relative_to):
     """Returns a path relative to another path.
 
@@ -203,9 +222,6 @@ def _collect_files(
                 sets.insert(hdrs_set, src)
         srcs_set = sets.difference(srcs_set, hdrs_set)
 
-    # TODO(chuck): Move the augmentation of the public_includes here from
-    # swiftpkg_build_files.
-
     # If public includes were specified, then use them. Otherwise, add every
     # directory that holds a public header file
     if len(public_includes) == 0:
@@ -247,5 +263,6 @@ clang_files = struct(
     is_hdr = _is_hdr,
     is_include_hdr = _is_include_hdr,
     is_public_modulemap = _is_public_modulemap,
+    is_under_path = _is_under_path,
     relativize = _relativize,
 )

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -105,7 +105,6 @@ def _swift_test_from_target(target, attrs):
 def _clang_target_build_file(repository_ctx, pkg_ctx, target):
     repo_name = repository_ctx.name
     pkg_path = pkg_ctx.pkg_info.path
-    # pkg_path_prefix = pkg_path + "/"
 
     # Absolute path to the target. This is typically used for filesystem
     # actions, not for values added to the cc_library or objc_library.
@@ -167,7 +166,6 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             paths.normalize(paths.join(pkg_path, pi))
             for pi in public_includes
         ],
-        # remove_prefix = pkg_path_prefix,
         relative_to = pkg_path,
     )
     deps = lists.flatten([
@@ -253,7 +251,6 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         abs_ehd = paths.normalize(paths.join(pkg_path, ehd))
         hdr_paths = repository_files.list_files_under(repository_ctx, abs_ehd)
         hdr_paths = [
-            # hp.removeprefix(pkg_path_prefix)
             clang_files.relativize(hp, pkg_path)
             for hp in hdr_paths
             if hp.endswith(".h")

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -263,6 +263,9 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         attrs["srcs"] = srcs
 
     if clang_files.has_objc_srcs(organized_files.srcs):
+        # Enable clang module support.
+        # https://bazel.build/reference/be/objective-c#objc_library.enable_modules
+        attrs["enable_modules"] = True
         kind = objc_kinds.library
     else:
         kind = clang_kinds.library

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -223,8 +223,6 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         ])
         attrs["linkopts"] = linkopts
 
-    if len(public_includes) > 0:
-        attrs["includes"] = sets.to_list(sets.make(public_includes))
     if len(local_includes) > 0:
         # The `includes` attribute adds includes as -isystem which propagates
         # to cc_XXX that depend upon the library. Providing includes as -I only
@@ -260,11 +258,23 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         ]
         srcs.extend(hdr_paths)
 
+    public_includes_set = sets.make(public_includes)
     srcs_set = sets.make(srcs)
     if len(hdrs) > 0:
+        attrs["hdrs"] = hdrs
         hdrs_set = sets.make(hdrs)
         srcs_set = sets.difference(srcs_set, hdrs_set)
-        attrs["hdrs"] = hdrs
+
+        # Make sure that any directories that contain public headers is
+        # included in the public includes. The processing of a modulemap can
+        # add new headers. The directory for these headers must be part of the
+        # publicly available includes.
+        for hdr in hdrs:
+            hdr_dir = paths.dirname(hdr)
+            sets.insert(public_includes_set, hdr_dir)
+
+    if sets.length(public_includes_set) > 0:
+        attrs["includes"] = sets.to_list(public_includes_set)
 
     if sets.length(srcs_set) > 0:
         srcs = sets.to_list(srcs_set)

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -162,6 +162,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
     organized_files = clang_files.collect_files(
         repository_ctx,
         all_srcs,
+        target.c99name,
         public_includes = [
             paths.normalize(paths.join(pkg_path, pi))
             for pi in public_includes
@@ -266,6 +267,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         # Enable clang module support.
         # https://bazel.build/reference/be/objective-c#objc_library.enable_modules
         attrs["enable_modules"] = True
+        attrs["module_name"] = target.c99name
         kind = objc_kinds.library
     else:
         kind = clang_kinds.library

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -238,12 +238,9 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         if target.path != ".":
             # Ensure that any header files that are outside of the target path are
             # included in the srcs.
-            target_path_prefix = target.path + "/"
             for li in local_includes:
                 normalized_li = paths.normalize(li)
-                if normalized_li == target.path:
-                    continue
-                if normalized_li.startswith(target_path_prefix):
+                if clang_files.is_under_path(normalized_li, target.path):
                     continue
                 extra_hdr_dirs.append(normalized_li)
 

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -105,7 +105,7 @@ def _swift_test_from_target(target, attrs):
 def _clang_target_build_file(repository_ctx, pkg_ctx, target):
     repo_name = repository_ctx.name
     pkg_path = pkg_ctx.pkg_info.path
-    pkg_path_prefix = pkg_path + "/"
+    # pkg_path_prefix = pkg_path + "/"
 
     # Absolute path to the target. This is typically used for filesystem
     # actions, not for values added to the cc_library or objc_library.
@@ -157,7 +157,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
 
     # Organize the source files
     # Be sure that the all_srcs and the public_includes that are passed to
-    # `collect_files` are all absolute paths.  The remove_prefix option will
+    # `collect_files` are all absolute paths.  The relative_to option will
     # ensure that the output values are relative to the package path.
     organized_files = clang_files.collect_files(
         repository_ctx,
@@ -167,7 +167,8 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             paths.normalize(paths.join(pkg_path, pi))
             for pi in public_includes
         ],
-        remove_prefix = pkg_path_prefix,
+        # remove_prefix = pkg_path_prefix,
+        relative_to = pkg_path,
     )
     deps = lists.flatten([
         pkginfo_target_deps.bazel_label_strs(pkg_ctx, td)
@@ -252,7 +253,8 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         abs_ehd = paths.normalize(paths.join(pkg_path, ehd))
         hdr_paths = repository_files.list_files_under(repository_ctx, abs_ehd)
         hdr_paths = [
-            hp.removeprefix(pkg_path_prefix)
+            # hp.removeprefix(pkg_path_prefix)
+            clang_files.relativize(hp, pkg_path)
             for hp in hdr_paths
             if hp.endswith(".h")
         ]

--- a/swiftpkg/tests/clang_files_tests.bzl
+++ b/swiftpkg/tests/clang_files_tests.bzl
@@ -70,10 +70,54 @@ def _relativize_test(ctx):
 
 relativize_test = unittest.make(_relativize_test)
 
+def _is_under_path_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(
+            path = "/parent",
+            parent = "/parent",
+            exp = True,
+            msg = "path equals parent",
+        ),
+        struct(
+            path = "/parent/foo",
+            parent = "/parent",
+            exp = True,
+            msg = "path is under parent",
+        ),
+        struct(
+            path = "/parent",
+            parent = "/parent/",
+            exp = True,
+            msg = "path equals parent, parent has trailing slash",
+        ),
+        struct(
+            path = "/parent.txt",
+            parent = "/parent",
+            exp = False,
+            msg = "path has similar prefix to parent",
+        ),
+        struct(
+            path = "/another",
+            parent = "/parent",
+            exp = False,
+            msg = "path is not under parent",
+        ),
+    ]
+    for t in tests:
+        actual = clang_files.is_under_path(t.path, t.parent)
+        asserts.equals(env, t.exp, actual, t.msg)
+
+    return unittest.end(env)
+
+is_under_path_test = unittest.make(_is_under_path_test)
+
 def clang_files_test_suite():
     return unittest.suite(
         "clang_files_tests",
         is_include_hdr_test,
         is_public_modulemap_test,
         relativize_test,
+        is_under_path_test,
     )


### PR DESCRIPTION
- When retrieving headers from a modulemap, try to only return headers for the named module.
- Ensure that the public includes are updated with the path to any headers declared in a modulemap.
- Fix path relativization to handle the case when the path is the same as the relativize_to.
- Ensure that `objc_library` declarations enable clang module support.

Related to #153.