### PR TITLE
feat: detect all Bazel header file types and other fixes

### DIFF
--- a/examples/firebase_example/.bazelrc
+++ b/examples/firebase_example/.bazelrc
@@ -12,3 +12,10 @@ try-import %workspace%/../../local.bazelrc
 # https://stackoverflow.com/questions/40260242/how-to-set-c-standard-version-when-build-with-bazel/43388168#43388168
 build --cxxopt='-std=c++14'
 
+# Firebase SPM support requires `-ObjC` linker option.
+# https://github.com/firebase/firebase-ios-sdk/blob/master/SwiftPackageManager.md#requirements
+build --linkopt='-ObjC'
+
+# Since this project is not building a ios_application or ios_unit_test, we need to specify an Apple platform.
+# https://github.com/bazelbuild/rules_swift/issues/240#issuecomment-708885118
+build --apple_platform_type=ios

--- a/examples/firebase_example/WORKSPACE
+++ b/examples/firebase_example/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "xcmetrics_example")
+workspace(name = "firebase_example")
 
 local_repository(
     name = "cgrindel_swift_bazel",

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -9,9 +9,13 @@ load("//swiftpkg/internal/modulemap_parser:parser.bzl", modulemap_parser = "pars
 # Directory names that may include public header files.
 _PUBLIC_HDR_DIRNAMES = ["include", "public"]
 
+# Supported header extensions
+# https://bazel.build/reference/be/c-cpp#cc_library.srcs
+_HEADER_EXTS = [".h", ".hh", ".hpp", ".hxx", ".inc", ".inl", ".H"]
+
 def _is_hdr(path):
     _root, ext = paths.split_extension(path)
-    return ext == ".h"
+    return lists.contains(_HEADER_EXTS, ext)
 
 def _is_include_hdr(path, public_includes = None):
     """Determines whether the path is a public header.

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -250,7 +250,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         hdr_paths = [
             clang_files.relativize(hp, pkg_path)
             for hp in hdr_paths
-            if hp.endswith(".h")
+            if clang_files.is_hdr(hp)
         ]
         srcs.extend(hdr_paths)
 

--- a/swiftpkg/tests/clang_files_tests.bzl
+++ b/swiftpkg/tests/clang_files_tests.bzl
@@ -4,6 +4,28 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//swiftpkg/internal:clang_files.bzl", "clang_files")
 
+def _is_hdr_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(path = "foo.h", exp = True, msg = ".h"),
+        struct(path = "foo.hh", exp = True, msg = ".hh"),
+        struct(path = "foo.hpp", exp = True, msg = ".hpp"),
+        struct(path = "foo.hxx", exp = True, msg = ".hxx"),
+        struct(path = "foo.inc", exp = True, msg = ".inc"),
+        struct(path = "foo.inl", exp = True, msg = ".inl"),
+        struct(path = "foo.H", exp = True, msg = ".H"),
+        struct(path = "foo", exp = False, msg = "no extension"),
+        struct(path = "foo.c", exp = False, msg = "wrong extension"),
+    ]
+    for t in tests:
+        actual = clang_files.is_hdr(t.path)
+        asserts.equals(env, t.exp, actual, t.msg)
+
+    return unittest.end(env)
+
+is_hdr_test = unittest.make(_is_hdr_test)
+
 def _is_include_hdr_test(ctx):
     env = unittest.begin(ctx)
 
@@ -116,6 +138,7 @@ is_under_path_test = unittest.make(_is_under_path_test)
 def clang_files_test_suite():
     return unittest.suite(
         "clang_files_tests",
+        is_hdr_test,
         is_include_hdr_test,
         is_public_modulemap_test,
         relativize_test,


### PR DESCRIPTION
- Detect all Bazel supported header files.
- Fix the workspace name of the firebase example.
- Add flags to `.bazelrc` that are required for the firebase example.

Related to #153.