### PR TITLE
fix: remove inappropriate inclusion of public header directories

### DIFF
--- a/examples/firebase_example/.bazelrc
+++ b/examples/firebase_example/.bazelrc
@@ -19,3 +19,11 @@ build --linkopt='-ObjC'
 # Since this project is not building a ios_application or ios_unit_test, we need to specify an Apple platform.
 # https://github.com/bazelbuild/rules_swift/issues/240#issuecomment-708885118
 build --apple_platform_type=ios
+
+# TODO: Figure out how to support cxxLanguageStandard in Swift manifest. 
+# Should we scan all of the manifests and pick the highest one?
+# The problem is that we do not want to just add it to the cxxopts 
+# for each target. It would override the values in the .bazelrc.
+# Also, I think that you do not want modules linked with different standards.
+
+# build --cxxopt='-std=gnu++14'

--- a/examples/firebase_example/.bazelrc
+++ b/examples/firebase_example/.bazelrc
@@ -19,11 +19,3 @@ build --linkopt='-ObjC'
 # Since this project is not building a ios_application or ios_unit_test, we need to specify an Apple platform.
 # https://github.com/bazelbuild/rules_swift/issues/240#issuecomment-708885118
 build --apple_platform_type=ios
-
-# TODO: Figure out how to support cxxLanguageStandard in Swift manifest. 
-# Should we scan all of the manifests and pick the highest one?
-# The problem is that we do not want to just add it to the cxxopts 
-# for each target. It would override the values in the .bazelrc.
-# Also, I think that you do not want modules linked with different standards.
-
-# build --cxxopt='-std=gnu++14'

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -13,6 +13,11 @@ _PUBLIC_HDR_DIRNAMES = ["include", "public"]
 # https://bazel.build/reference/be/c-cpp#cc_library.srcs
 _HEADER_EXTS = [".h", ".hh", ".hpp", ".hxx", ".inc", ".inl", ".H"]
 
+# Acceptable sources clang and objc:
+# https://bazel.build/reference/be/c-cpp#cc_library.srcs
+# https://bazel.build/reference/be/objective-c#objc_library.srcs
+_SRC_EXTS = [".c", ".cc", ".S", ".so", ".o", ".m"]
+
 def _is_hdr(path):
     _root, ext = paths.split_extension(path)
     return lists.contains(_HEADER_EXTS, ext)
@@ -171,15 +176,12 @@ def _collect_files(
     for orig_path in all_srcs:
         path = _relativize(orig_path, relative_to)
         _root, ext = paths.split_extension(path)
-        if ext == ".h":
+        if lists.contains(_HEADER_EXTS, ext):
             if _is_include_hdr(orig_path, public_includes = public_includes):
                 sets.insert(hdrs_set, path)
             else:
                 sets.insert(srcs_set, path)
-        elif lists.contains([".c", ".cc", ".S", ".so", ".o", ".m"], ext):
-            # Acceptable sources clang and objc:
-            # https://bazel.build/reference/be/c-cpp#cc_library.srcs
-            # https://bazel.build/reference/be/objective-c#objc_library.srcs
+        elif lists.contains(_SRC_EXTS, ext):
             sets.insert(srcs_set, path)
         elif ext == ".modulemap" and _is_public_modulemap(path):
             if modulemap != None:

--- a/swiftpkg/internal/pkginfo_target_deps.bzl
+++ b/swiftpkg/internal/pkginfo_target_deps.bzl
@@ -61,12 +61,6 @@ Unable to resolve target reference target dependency for {module_name}.\
                 fail("""\
 Did not find external dependency with name/identity {}.\
 """.format(prod_ref.dep_name))
-
-            # DEBUG BEGIN
-            print("*** CHUCK dep: ", dep)
-            print("*** CHUCK prod_ref.product_name: ", prod_ref.product_name)
-
-            # DEBUG END
             labels = deps_indexes.resolve_product_labels(
                 deps_index = pkg_ctx.deps_index_ctx.deps_index,
                 identity = dep.identity,

--- a/swiftpkg/internal/pkginfo_target_deps.bzl
+++ b/swiftpkg/internal/pkginfo_target_deps.bzl
@@ -61,6 +61,12 @@ Unable to resolve target reference target dependency for {module_name}.\
                 fail("""\
 Did not find external dependency with name/identity {}.\
 """.format(prod_ref.dep_name))
+
+            # DEBUG BEGIN
+            print("*** CHUCK dep: ", dep)
+            print("*** CHUCK prod_ref.product_name: ", prod_ref.product_name)
+
+            # DEBUG END
             labels = deps_indexes.resolve_product_labels(
                 deps_index = pkg_ctx.deps_index_ctx.deps_index,
                 identity = dep.identity,
@@ -68,10 +74,10 @@ Did not find external dependency with name/identity {}.\
             )
             if len(labels) == 0:
                 fail("""\
-Unable to resolve product reference target dependency for product {prod_name} provided by {dep_id}.
+Unable to resolve product reference target dependency for product {prod_name} provided by {dep_name}.
 """.format(
                     prod_name = prod_ref.product_name,
-                    dep_id = prod_ref.dep_identity,
+                    dep_name = prod_ref.dep_name,
                 ))
 
         else:

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -261,17 +261,6 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         hdrs_set = sets.make(hdrs)
         srcs_set = sets.difference(srcs_set, hdrs_set)
 
-        # TODO(chuck): I think that this logic should only add the include if a
-        # parent directory is not already specified.
-
-        # # Make sure that any directories that contain public headers is
-        # # included in the public includes. The processing of a modulemap can
-        # # add new headers. The directory for these headers must be part of the
-        # # publicly available includes.
-        # for hdr in hdrs:
-        #     hdr_dir = paths.dirname(hdr)
-        #     sets.insert(public_includes_set, hdr_dir)
-
     if sets.length(public_includes_set) > 0:
         attrs["includes"] = sets.to_list(public_includes_set)
 

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -261,13 +261,16 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         hdrs_set = sets.make(hdrs)
         srcs_set = sets.difference(srcs_set, hdrs_set)
 
-        # Make sure that any directories that contain public headers is
-        # included in the public includes. The processing of a modulemap can
-        # add new headers. The directory for these headers must be part of the
-        # publicly available includes.
-        for hdr in hdrs:
-            hdr_dir = paths.dirname(hdr)
-            sets.insert(public_includes_set, hdr_dir)
+        # TODO(chuck): I think that this logic should only add the include if a
+        # parent directory is not already specified.
+
+        # # Make sure that any directories that contain public headers is
+        # # included in the public includes. The processing of a modulemap can
+        # # add new headers. The directory for these headers must be part of the
+        # # publicly available includes.
+        # for hdr in hdrs:
+        #     hdr_dir = paths.dirname(hdr)
+        #     sets.insert(public_includes_set, hdr_dir)
 
     if sets.length(public_includes_set) > 0:
         attrs["includes"] = sets.to_list(public_includes_set)


### PR DESCRIPTION
- Adding the recursive list of header paths caused compilation issues building [firebase/abseil-cpp-SwiftPM](https://github.com/firebase/abseil-cpp-SwiftPM).
- Fixed bug with header identification not using the supported list of headers.
- Fixed bug in fail call.

Related to #153.