### PR TITLE
chore: refactor build settings to support conditions

### DIFF
--- a/config_settings/platform_type/BUILD.bazel
+++ b/config_settings/platform_type/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+
+package(default_visibility = ["//visibility:public"])
+
+bzlformat_pkg(name = "bzlformat")
+
+APPLE_PLATFORM_TYPES = [
+    "macos",
+    "ios",
+    "tvos",
+    "watchos",
+]
+
+[
+    config_setting(
+        name = platform_type,
+        values = {"apple_platform_type": platform_type},
+    )
+    for platform_type in APPLE_PLATFORM_TYPES
+]

--- a/swiftpkg/internal/build_decls.bzl
+++ b/swiftpkg/internal/build_decls.bzl
@@ -4,6 +4,18 @@ load("@bazel_skylib//lib:sets.bzl", "sets")
 load(":starlark_codegen.bzl", scg = "starlark_codegen")
 
 def _new(kind, name, attrs = {}, comments = []):
+    """Create a rule/macro declaration for a build file.
+
+    Args:
+        kind: The kind of rule/macro as a `string`.
+        name: The name attribute value of the declaration as a `string`.
+        attrs: Optional. The attributes for the declaration as a `dict`.
+        comments: Optional. Comments that appear before the declaration as a
+            `list` of `string` values.
+
+    Returns:
+        A `struct` representing a rule/macro declaration.
+    """
     return struct(
         kind = kind,
         name = name,
@@ -66,6 +78,18 @@ def _uniq(decls):
     return results
 
 def _get(decls, name, fail_if_not_found = True):
+    """Returns the declaration with the specified name.
+
+    Args:
+        decls: A `list` of `struct` values as returned by `build_decls.new`.
+        name: The name of the desired declaration as a `string`.
+        fail_if_not_found: Optional. A `bool` the determines whether to fail
+            if the declaration is not found.
+
+    Returns:
+        The declaration `struct`, if it is found. Otherwise, it fails or
+        returns `None` depending upon the value of `fail_if_not_found`.
+    """
     for decl in decls:
         if decl.name == name:
             return decl
@@ -74,6 +98,16 @@ def _get(decls, name, fail_if_not_found = True):
     return None
 
 def _new_fn_call(fn_name, *args, **kwargs):
+    """Create a function call.
+
+    Args:
+        fn_name: The name of the function as a `string`.
+        *args: Positional arguments for the function call.
+        **kwargs: Named arguments for the function call.
+
+    Returns:
+        A `struct` representing a Starlark function call.
+    """
     return struct(
         fn_name = fn_name,
         args = args,

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -327,6 +327,8 @@ def _new_from_parsed_json(dump_manifest, desc_manifest):
         targets = targets,
     )
 
+# MARK: - Swift Package
+
 def _new(
         name,
         path,
@@ -364,6 +366,8 @@ def _new(
         targets = targets,
     )
 
+# MARK: - Platform
+
 def _new_platform(name, version):
     """Creates a `struct` with information about a platform.
 
@@ -378,6 +382,8 @@ def _new_platform(name, version):
         name = name,
         version = version,
     )
+
+# MARK: - External Dependency
 
 def _new_dependency(identity, name, type, url, requirement):
     """Creates a `struct` representing an external dependency for a Swift \
@@ -435,6 +441,8 @@ def _new_version_range(lower, upper):
         lower = lower,
         upper = upper,
     )
+
+# MARK: - Product
 
 def _new_product_type(executable = False, library = None, plugin = False):
     """Creates a product type.
@@ -504,6 +512,8 @@ def _new_product(name, type, targets):
         targets = targets,
     )
 
+# MARK: - Dependency References
+
 def _new_product_reference(product_name, dep_name):
     """Creates a product reference.
 
@@ -568,6 +578,8 @@ A target dependency must have one of the following: `by_name`, `product`, `targe
         product = product,
         target = target,
     )
+
+# MARK: - Target
 
 def _new_target(
         name,
@@ -650,6 +662,51 @@ def _new_target(
         product_memberships = product_memberships,
     )
 
+# MARK: - Build Settings
+
+def _new_build_setting_condition(platforms = None, configuration = None):
+    if platforms == None and configuration == None:
+        fail("""\
+A build setting condition must have `platforms` or `configuration` set.\
+""")
+    if platforms != None:
+        for platform in platforms:
+            validations.in_list(
+                spm_platforms.all_values,
+                platform,
+                "Unrecognized platform. platform:",
+            )
+
+    if configuration != None:
+        validations.in_list(
+            spm_configurations.all_values,
+            configuration,
+            "Unrecognized configuration. configuration:",
+        )
+
+    return struct(
+        platforms = platforms,
+        configuration = configuration,
+    )
+
+def _new_build_setting_data(name, value, condition = None):
+    """Create a build setting data struct.
+
+    Args:
+        name: The name of the build setting as a `string`.
+        value: The value for the build setting as a `list`.
+        condition: Optional. A `struct` as returned by
+            `pkginfos.new_build_setting_condition`.
+
+    Returns:
+        A `struct` representing a build setting.
+    """
+    return struct(
+        name = name,
+        value = value,
+        condition = condition,
+    )
+
 def _new_clang_settings(defines, hdr_srch_paths):
     return struct(
         defines = defines,
@@ -666,11 +723,15 @@ def _new_linker_settings(linked_libraries):
         linked_libraries = linked_libraries,
     )
 
+# MARK: - Binary Target
+
 def _new_artifact_download_info(url, checksum):
     return struct(
         url = url,
         checksum = checksum,
     )
+
+# MARK: - Constants
 
 target_types = struct(
     binary = "binary",
@@ -713,10 +774,54 @@ library_type_kinds = struct(
     all_values = ["automatic", "dynamic", "static"],
 )
 
+# Derived from BuildConfiguration values
+# https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/BuildSettings.swift
+spm_configurations = struct(
+    debug = "debug",
+    release = "release",
+    all_values = [
+        "debug",
+        "release",
+    ],
+)
+
+# Derived from Platform values
+# https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/SupportedPlatforms.swift
+spm_platforms = struct(
+    macos = "macos",
+    maccatalyst = "maccatalyst",
+    ios = "ios",
+    tvos = "tvos",
+    watchos = "watchos",
+    driverkit = "driverkit",
+    linux = "linux",
+    windows = "windows",
+    android = "android",
+    wasi = "wasi",
+    openbsd = "openbsd",
+    all_values = [
+        "macos",
+        "maccatalyst",
+        "ios",
+        "tvos",
+        "watchos",
+        "driverkit",
+        "linux",
+        "windows",
+        "android",
+        "wasi",
+        "openbsd",
+    ],
+)
+
+# MARK: - API Definition
+
 pkginfos = struct(
     get = _get,
     new = _new,
     new_artifact_download_info = _new_artifact_download_info,
+    new_build_setting_condition = _new_build_setting_condition,
+    new_build_setting_data = _new_build_setting_data,
     new_by_name_reference = _new_by_name_reference,
     new_clang_settings = _new_clang_settings,
     new_dependency = _new_dependency,

--- a/swiftpkg/internal/starlark_codegen.bzl
+++ b/swiftpkg/internal/starlark_codegen.bzl
@@ -132,9 +132,9 @@ def _process_complex_types(out):
         finished = False
 
         if v_type == "list":
-            new_out.extend(_list(v, current_indent))
+            new_out.extend(_process_list(v, current_indent))
         elif v_type == "dict":
-            new_out.extend(_dict(v, current_indent))
+            new_out.extend(_process_dict(v, current_indent))
         elif v_type == "struct":
             to_starlark_fn = getattr(v, "to_starlark_parts", None)
             if to_starlark_fn == None:
@@ -145,7 +145,7 @@ def _process_complex_types(out):
 
     return new_out, finished
 
-def _list(val, current_indent):
+def _process_list(val, current_indent):
     val_len = len(val)
     if val_len == 0:
         return ["[]"]
@@ -164,7 +164,7 @@ def _list(val, current_indent):
     output.extend([_indent(current_indent), "]"])
     return output
 
-def _dict(val, current_indent):
+def _process_dict(val, current_indent):
     if len(val) == 0:
         return ["{}"]
 

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -207,11 +207,11 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         local_includes.extend(organized_files.private_includes)
     if target.clang_settings != None:
         if len(target.clang_settings.defines) > 0:
-            # TODO(chuck): Support conditional
+            # GH153: Support conditional
             for bs in target.clang_settings.defines:
                 attrs["defines"].extend(bs.value)
         if len(target.clang_settings.hdr_srch_paths) > 0:
-            # TODO(chuck): Support conditional
+            # GH153: Support conditional
             hdr_srch_paths = lists.flatten([
                 bs.value
                 for bs in target.clang_settings.hdr_srch_paths
@@ -221,7 +221,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
                 for p in hdr_srch_paths
             ])
     if target.linker_settings != None:
-        # TODO(chuck): Support conditional
+        # GH153: Support conditional
         linkopts = attrs.get("linkopts", default = [])
         copts = attrs.get("copts", default = [])
         if len(target.linker_settings.linked_libraries) > 0:

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -222,23 +222,26 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             ])
     if target.linker_settings != None:
         # TODO(chuck): Support conditional
+        linkopts = attrs.get("linkopts", default = [])
+        copts = attrs.get("copts", default = [])
         if len(target.linker_settings.linked_libraries) > 0:
             linked_libraries = lists.flatten([
                 bs.value
                 for bs in target.linker_settings.linked_libraries
             ])
-            linkopts = attrs.get("linkopts", default = [])
             linkopts.extend(["-l{}".format(ll) for ll in linked_libraries])
-            attrs["linkopts"] = linkopts
         if len(target.linker_settings.linked_frameworks) > 0:
             # This is using a objc_library attr.
             linked_frameworks = lists.flatten([
                 bs.value
                 for bs in target.linker_settings.linked_frameworks
             ])
-            sdk_frameworks = attrs.get("sdk_frameworks", default = [])
-            sdk_frameworks.extend(linked_frameworks)
-            attrs["sdk_frameworks"] = sdk_frameworks
+            copts.extend([
+                "-framework {}".format(lf)
+                for lf in linked_frameworks
+            ])
+        attrs["linkopts"] = linkopts
+        attrs["copts"] = copts
 
     if len(local_includes) > 0:
         # The `includes` attribute adds includes as -isystem which propagates

--- a/swiftpkg/tests/pkginfos_tests.bzl
+++ b/swiftpkg/tests/pkginfos_tests.bzl
@@ -57,10 +57,32 @@ def _new_from_parsed_json_for_swift_targets_test(ctx):
                         ),
                     ),
                 ],
+                clang_settings = pkginfos.new_clang_settings([
+                    pkginfos.new_build_setting_data(
+                        name = "headerSearchPath",
+                        value = ["../.."],
+                    ),
+                ]),
                 swift_settings = pkginfos.new_swift_settings([
                     pkginfos.new_build_setting_data(
                         name = "define",
                         value = ["COOL_SWIFT_DEFINE"],
+                    ),
+                ]),
+                linker_settings = pkginfos.new_linker_settings([
+                    pkginfos.new_build_setting_data(
+                        name = "linkedFramework",
+                        value = ["UIKit"],
+                        condition = pkginfos.new_build_setting_condition(
+                            platforms = ["ios", "tvos"],
+                        ),
+                    ),
+                    pkginfos.new_build_setting_data(
+                        name = "linkedFramework",
+                        value = ["AppKit"],
+                        condition = pkginfos.new_build_setting_condition(
+                            platforms = ["macos"],
+                        ),
                     ),
                 ]),
                 product_memberships = ["printstuff"],
@@ -240,6 +262,41 @@ _swift_arg_parser_dump_json = """
               }
             },
             "tool" : "swift"
+          },
+          {
+            "kind" : {
+              "headerSearchPath" : {
+                "_0" : "../.."
+              }
+            },
+            "tool" : "c"
+          },
+          {
+            "condition" : {
+              "platformNames" : [
+                "ios",
+                "tvos"
+              ]
+            },
+            "kind" : {
+              "linkedFramework" : {
+                "_0" : "UIKit"
+              }
+            },
+            "tool" : "linker"
+          },
+          {
+            "condition" : {
+              "platformNames" : [
+                "macos"
+              ]
+            },
+            "kind" : {
+              "linkedFramework" : {
+                "_0" : "AppKit"
+              }
+            },
+            "tool" : "linker"
           }
       ],
       "type" : "executable"

--- a/swiftpkg/tests/pkginfos_tests.bzl
+++ b/swiftpkg/tests/pkginfos_tests.bzl
@@ -57,9 +57,12 @@ def _new_from_parsed_json_for_swift_targets_test(ctx):
                         ),
                     ),
                 ],
-                swift_settings = pkginfos.new_swift_settings(
-                    defines = ["COOL_SWIFT_DEFINE"],
-                ),
+                swift_settings = pkginfos.new_swift_settings([
+                    pkginfos.new_build_setting_data(
+                        name = "define",
+                        value = ["COOL_SWIFT_DEFINE"],
+                    ),
+                ]),
                 product_memberships = ["printstuff"],
             ),
             pkginfos.new_target(
@@ -118,13 +121,22 @@ def _new_from_parsed_json_for_clang_targets_test(ctx):
             "libbar/src",
             "libbar/sharpyuv",
         ],
-        clang_settings = pkginfos.new_clang_settings(
-            defines = ["__APPLE_USE_RFC_3542"],
-            hdr_srch_paths = ["libbar"],
-        ),
-        linker_settings = pkginfos.new_linker_settings(
-            linked_libraries = ["foo"],
-        ),
+        clang_settings = pkginfos.new_clang_settings([
+            pkginfos.new_build_setting_data(
+                name = "define",
+                value = ["__APPLE_USE_RFC_3542"],
+            ),
+            pkginfos.new_build_setting_data(
+                name = "headerSearchPath",
+                value = ["libbar"],
+            ),
+        ]),
+        linker_settings = pkginfos.new_linker_settings([
+            pkginfos.new_build_setting_data(
+                name = "linkedLibrary",
+                value = ["foo"],
+            ),
+        ]),
         public_hdrs_path = "include",
         product_memberships = ["libbar"],
     )


### PR DESCRIPTION
- Refactor how build settings are read and stored. This provides a means for supporting conditions on the build settings.
- Added some missing documentation.
- Add `//config_settings/platform_types` that will be used for platform name conditions.

Related to #153.