### PR TITLE
feat: support expressions and operators in Starlark code generation

### DIFF
--- a/swiftpkg/internal/build_decls.bzl
+++ b/swiftpkg/internal/build_decls.bzl
@@ -29,14 +29,14 @@ def _to_starlark_parts(decl, indent):
     for c in decl.comments:
         parts.append(scg.indent(indent, "{}\n".format(c)))
     parts.append(scg.indent(indent, "{}(\n".format(decl.kind)))
-    parts.extend(scg.attr("name", decl.name, indent + 1))
+    parts.extend(scg.new_attr("name", decl.name, indent + 1))
 
     # Sort the keys to ensure that we have a consistent output. It would be
     # ideal to output them in a manner that matches Buildifier output rules.
     keys = sorted(decl.attrs.keys())
     for key in keys:
         val = decl.attrs[key]
-        parts.extend(scg.attr(key, val, indent + 1))
+        parts.extend(scg.new_attr(key, val, indent + 1))
     parts.append(scg.indent(indent, ")"))
 
     return parts
@@ -97,54 +97,8 @@ def _get(decls, name, fail_if_not_found = True):
         fail("Failed to find build declaration. name:", name)
     return None
 
-def _new_fn_call(fn_name, *args, **kwargs):
-    """Create a function call.
-
-    Args:
-        fn_name: The name of the function as a `string`.
-        *args: Positional arguments for the function call.
-        **kwargs: Named arguments for the function call.
-
-    Returns:
-        A `struct` representing a Starlark function call.
-    """
-    return struct(
-        fn_name = fn_name,
-        args = args,
-        kwargs = kwargs,
-        to_starlark_parts = _fn_call_to_starlark_parts,
-    )
-
-def _fn_call_to_starlark_parts(fn_call, indent):
-    args_len = len(fn_call.args)
-    kwargs_len = len(fn_call.kwargs)
-    if args_len == 0 and kwargs_len == 0:
-        return [fn_call.fn_name, "()"]
-    if args_len == 1 and kwargs_len == 0:
-        return [
-            fn_call.fn_name,
-            "(",
-            scg.with_indent(indent, scg.normalize(fn_call.args[0])),
-            ")",
-        ]
-    parts = [fn_call.fn_name, "(\n"]
-    child_indent = indent + 1
-    for pos_arg in fn_call.args:
-        parts.extend([
-            scg.indent(child_indent),
-            scg.with_indent(child_indent, scg.normalize(pos_arg)),
-            ",\n",
-        ])
-    for name in fn_call.kwargs:
-        value = fn_call.kwargs[name]
-        parts.extend(scg.attr(name, value, child_indent))
-
-    parts.append(scg.indent(indent, ")"))
-    return parts
-
 build_decls = struct(
     get = _get,
     new = _new,
-    new_fn_call = _new_fn_call,
     uniq = _uniq,
 )

--- a/swiftpkg/internal/starlark_codegen.bzl
+++ b/swiftpkg/internal/starlark_codegen.bzl
@@ -240,18 +240,52 @@ def _fn_call_to_starlark_parts(fn_call, indent):
     parts.append(_indent(indent, ")"))
     return parts
 
+# MARK: - Operator
+
+def _new_op(operator):
+    """Create an operator.
+
+    Args:
+        operator: The operator as a `string`.
+
+    Returns:
+        A Starlark codegen `struct` representing the operator.
+    """
+    return struct(
+        operator = operator,
+        to_starlark_parts = _op_to_starlark_parts,
+    )
+
+# buildifier: disable=unused-variable
+def _op_to_starlark_parts(op, indent):
+    return [op.operator]
+
 # MARK: - Expression
 
 def _new_expr(first, *others):
-    parts = [first]
-    parts.extend(others)
+    """Create an expression with one or more members
+
+    Args:
+        first: The first member of the expression.
+        *others: Any additional members of the expression.
+
+    Returns:
+        A Starlark codegen `struct` representing the expression.
+    """
+    members = [first]
+    members.extend(others)
     return struct(
-        parts = parts,
+        members = members,
         to_starlark_parts = _expr_to_starlark_parts,
     )
 
 def _expr_to_starlark_parts(expr, indent):
-    parts = [_normalize(p) for p in expr.parts]
+    last_idx = len(expr.members) - 1
+    parts = []
+    for (idx, m) in enumerate(expr.members):
+        parts.append(_normalize(m))
+        if idx != last_idx:
+            parts.append(" ")
     return parts
 
 # MARK: - API Definition
@@ -261,6 +295,7 @@ starlark_codegen = struct(
     new_attr = _new_attr,
     new_expr = _new_expr,
     new_fn_call = _new_fn_call,
+    new_op = _new_op,
     normalize = _normalize,
     to_starlark = _to_starlark,
     with_indent = _with_indent,

--- a/swiftpkg/internal/starlark_codegen.bzl
+++ b/swiftpkg/internal/starlark_codegen.bzl
@@ -279,6 +279,7 @@ def _new_expr(first, *others):
         to_starlark_parts = _expr_to_starlark_parts,
     )
 
+# buildifier: disable=unused-variable
 def _expr_to_starlark_parts(expr, indent):
     last_idx = len(expr.members) - 1
     parts = []

--- a/swiftpkg/internal/starlark_codegen.bzl
+++ b/swiftpkg/internal/starlark_codegen.bzl
@@ -2,36 +2,7 @@
 
 _single_indent_str = "    "
 
-def _indent(count, suffix = ""):
-    """Generate the proper indent string based upon the count.
-
-    Args:
-        count: An `int` representing the number of indents to be generated.
-        suffix: Optional. A `string` that is appended to the generated indents.
-
-    Returns:
-        A `string` with the specified number of indets.
-    """
-    return (_single_indent_str * count) + suffix
-
-def _attr(name, value, indent):
-    """Generates the Starlark codegen parts that represents an attribute value.
-
-    Args:
-        name: The attribute name as a `string`.
-        value: The attribute value as any type supported by Starlark codegen.
-        indent: The number of indents to be used for the attribute.
-
-    Returns:
-        A `list` of Starlark codegen parts.
-    """
-    value = _normalize(value)
-    return [
-        _indent(indent),
-        "{} = ".format(name),
-        _with_indent(indent, value),
-        ",\n",
-    ]
+# MARK: - Simple Type Detection
 
 _simple_starlark_types = [
     "None",
@@ -57,18 +28,19 @@ def _is_simple_type(val):
             return True
     return False
 
-def _normalize(val):
-    """Attempts to simplify the value, if possible. Otherwise, returns the value unchanged.
+# MARK: - Indent
+
+def _indent(count, suffix = ""):
+    """Generate the proper indent string based upon the count.
 
     Args:
-        val: The value to evaluate.
+        count: An `int` representing the number of indents to be generated.
+        suffix: Optional. A `string` that is appended to the generated indents.
 
     Returns:
-        A `string` if the value is a simple type. Otherwise, the original value.
+        A `string` with the specified number of indets.
     """
-    if _is_simple_type(val):
-        return repr(val)
-    return val
+    return (_single_indent_str * count) + suffix
 
 def _with_indent(indent, value):
     """Wraps a value with a directive to evaluate it at a specified indent level.
@@ -84,6 +56,23 @@ def _with_indent(indent, value):
         with_indent = indent,
         wrapped_value = value,
     )
+
+# MARK: - Normalize
+
+def _normalize(val):
+    """Attempts to simplify the value, if possible. Otherwise, returns the value unchanged.
+
+    Args:
+        val: The value to evaluate.
+
+    Returns:
+        A `string` if the value is a simple type. Otherwise, the original value.
+    """
+    if _is_simple_type(val):
+        return repr(val)
+    return val
+
+# MARK: - Generate Starlark Code
 
 def _to_starlark(val):
     """Generates Starlark code from the provided value.
@@ -183,9 +172,78 @@ def _process_dict(val, current_indent):
     output.extend([_indent(current_indent), "}"])
     return output
 
+# MARK: - Attribute
+
+def _new_attr(name, value, indent):
+    """Generates the Starlark codegen parts that represents an attribute value.
+
+    Args:
+        name: The attribute name as a `string`.
+        value: The attribute value as any type supported by Starlark codegen.
+        indent: The number of indents to be used for the attribute.
+
+    Returns:
+        A `list` of Starlark codegen parts.
+    """
+    value = _normalize(value)
+    return [
+        _indent(indent),
+        "{} = ".format(name),
+        _with_indent(indent, value),
+        ",\n",
+    ]
+
+# MARK: - Function Call
+
+def _new_fn_call(fn_name, *args, **kwargs):
+    """Create a function call.
+
+    Args:
+        fn_name: The name of the function as a `string`.
+        *args: Positional arguments for the function call.
+        **kwargs: Named arguments for the function call.
+
+    Returns:
+        A `struct` representing a Starlark function call.
+    """
+    return struct(
+        fn_name = fn_name,
+        args = args,
+        kwargs = kwargs,
+        to_starlark_parts = _fn_call_to_starlark_parts,
+    )
+
+def _fn_call_to_starlark_parts(fn_call, indent):
+    args_len = len(fn_call.args)
+    kwargs_len = len(fn_call.kwargs)
+    if args_len == 0 and kwargs_len == 0:
+        return [fn_call.fn_name, "()"]
+    if args_len == 1 and kwargs_len == 0:
+        return [
+            fn_call.fn_name,
+            "(",
+            _with_indent(indent, _normalize(fn_call.args[0])),
+            ")",
+        ]
+    parts = [fn_call.fn_name, "(\n"]
+    child_indent = indent + 1
+    for pos_arg in fn_call.args:
+        parts.extend([
+            _indent(child_indent),
+            _with_indent(child_indent, _normalize(pos_arg)),
+            ",\n",
+        ])
+    for name in fn_call.kwargs:
+        value = fn_call.kwargs[name]
+        parts.extend(_new_attr(name, value, child_indent))
+
+    parts.append(_indent(indent, ")"))
+    return parts
+
 starlark_codegen = struct(
-    attr = _attr,
+    new_attr = _new_attr,
     indent = _indent,
+    new_fn_call = _new_fn_call,
     normalize = _normalize,
     to_starlark = _to_starlark,
     with_indent = _with_indent,

--- a/swiftpkg/internal/starlark_codegen.bzl
+++ b/swiftpkg/internal/starlark_codegen.bzl
@@ -251,7 +251,8 @@ def _new_expr(first, *others):
     )
 
 def _expr_to_starlark_parts(expr, indent):
-    return expr.parts
+    parts = [_normalize(p) for p in expr.parts]
+    return parts
 
 # MARK: - API Definition
 

--- a/swiftpkg/internal/starlark_codegen.bzl
+++ b/swiftpkg/internal/starlark_codegen.bzl
@@ -240,9 +240,25 @@ def _fn_call_to_starlark_parts(fn_call, indent):
     parts.append(_indent(indent, ")"))
     return parts
 
+# MARK: - Expression
+
+def _new_expr(first, *others):
+    parts = [first]
+    parts.extend(others)
+    return struct(
+        parts = parts,
+        to_starlark_parts = _expr_to_starlark_parts,
+    )
+
+def _expr_to_starlark_parts(expr, indent):
+    return expr.parts
+
+# MARK: - API Definition
+
 starlark_codegen = struct(
-    new_attr = _new_attr,
     indent = _indent,
+    new_attr = _new_attr,
+    new_expr = _new_expr,
     new_fn_call = _new_fn_call,
     normalize = _normalize,
     to_starlark = _to_starlark,

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -11,6 +11,7 @@ load(":pkginfo_target_deps.bzl", "pkginfo_target_deps")
 load(":pkginfo_targets.bzl", "pkginfo_targets")
 load(":pkginfos.bzl", "module_types", "target_types")
 load(":repository_files.bzl", "repository_files")
+load(":starlark_codegen.bzl", scg = "starlark_codegen")
 
 # MARK: - Target Entry Point
 
@@ -347,7 +348,7 @@ def _system_library_build_file(target):
 
 def _apple_dynamic_xcframework_import_build_file(target):
     load_stmts = [apple_dynamic_xcframework_import_load_stmt]
-    glob = build_decls.new_fn_call(
+    glob = scg.new_fn_call(
         "glob",
         ["{tpath}/*.xcframework/**".format(tpath = target.path)],
     )

--- a/swiftpkg/tests/build_decls_tests.bzl
+++ b/swiftpkg/tests/build_decls_tests.bzl
@@ -77,87 +77,10 @@ def _get_test(ctx):
 
 get_test = unittest.make(_get_test)
 
-def _fn_call_to_starlark_parts_test(ctx):
-    env = unittest.begin(ctx)
-
-    fn_call = build_decls.new_fn_call("foo")
-    expected = "foo()"
-    code = scg.to_starlark(fn_call)
-    asserts.equals(env, expected, code)
-
-    fn_call = build_decls.new_fn_call("foo", "first")
-    expected = """\
-foo("first")\
-"""
-    code = scg.to_starlark(fn_call)
-    asserts.equals(env, expected, code)
-
-    fn_call = build_decls.new_fn_call("foo", ["item0"])
-    expected = """\
-foo(["item0"])\
-"""
-    code = scg.to_starlark(fn_call)
-    asserts.equals(env, expected, code)
-
-    fn_call = build_decls.new_fn_call("foo", ["item0", "item1"])
-    expected = """\
-foo([
-    "item0",
-    "item1",
-])\
-"""
-    code = scg.to_starlark(fn_call)
-    asserts.equals(env, expected, code)
-
-    fn_call = build_decls.new_fn_call("foo", 123, 456)
-    expected = """\
-foo(
-    123,
-    456,
-)\
-"""
-    code = scg.to_starlark(fn_call)
-    asserts.equals(env, expected, code)
-
-    fn_call = build_decls.new_fn_call(
-        "foo",
-        zebra = "goodbye",
-        bar = "hello",
-    )
-    expected = """\
-foo(
-    zebra = "goodbye",
-    bar = "hello",
-)\
-"""
-    code = scg.to_starlark(fn_call)
-    asserts.equals(env, expected, code)
-
-    fn_call = build_decls.new_fn_call(
-        "foo",
-        "chicken",
-        zebra = "goodbye",
-        bar = "hello",
-    )
-    expected = """\
-foo(
-    "chicken",
-    zebra = "goodbye",
-    bar = "hello",
-)\
-"""
-    code = scg.to_starlark(fn_call)
-    asserts.equals(env, expected, code)
-
-    return unittest.end(env)
-
-fn_call_to_starlark_parts_test = unittest.make(_fn_call_to_starlark_parts_test)
-
 def build_decls_test_suite():
     return unittest.suite(
         "build_decls_tests",
         to_starlark_parts_test,
         uniq_test,
         get_test,
-        fn_call_to_starlark_parts_test,
     )

--- a/swiftpkg/tests/starlark_codegen_tests.bzl
+++ b/swiftpkg/tests/starlark_codegen_tests.bzl
@@ -237,20 +237,18 @@ new_expr_test = unittest.make(_new_expr_test)
 def _expr_to_starlark_parts_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
-
-    # tests = [
-    #     struct(
-    #         expr = scg.new_expr("hello"),
-    #         exp = """\
-    # "hello"\
-    # """,
-    #         msg = "a single part",
-    #     ),
-    # ]
-    # for t in tests:
-    #     actual = scg.to_starlark(t.expr)
-    #     asserts.equals(env, t.exp, actual, t.msg)
+    tests = [
+        struct(
+            expr = scg.new_expr("hello"),
+            exp = """\
+"hello"\
+""",
+            msg = "a single part",
+        ),
+    ]
+    for t in tests:
+        actual = scg.to_starlark(t.expr)
+        asserts.equals(env, t.exp, actual, t.msg)
 
     return unittest.end(env)
 

--- a/swiftpkg/tests/starlark_codegen_tests.bzl
+++ b/swiftpkg/tests/starlark_codegen_tests.bzl
@@ -211,6 +211,24 @@ foo(
 
 fn_call_to_starlark_parts_test = unittest.make(_fn_call_to_starlark_parts_test)
 
+def _op_to_starlark_parts_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(
+            op = scg.new_op("+"),
+            exp = "+",
+            msg = "plus",
+        ),
+    ]
+    for t in tests:
+        actual = scg.to_starlark(t.op)
+        asserts.equals(env, t.exp, actual, t.msg)
+
+    return unittest.end(env)
+
+op_to_starlark_parts_test = unittest.make(_op_to_starlark_parts_test)
+
 def _new_expr_test(ctx):
     env = unittest.begin(ctx)
 
@@ -227,7 +245,7 @@ def _new_expr_test(ctx):
         ),
     ]
     for t in tests:
-        actual = t.expr.parts
+        actual = t.expr.members
         asserts.equals(env, t.exp, actual, t.msg)
 
     return unittest.end(env)
@@ -245,6 +263,13 @@ def _expr_to_starlark_parts_test(ctx):
 """,
             msg = "a single part",
         ),
+        struct(
+            expr = scg.new_expr("hello", scg.new_op("+"), "goodbye"),
+            exp = """\
+"hello" + "goodbye"\
+""",
+            msg = "operator with two strings",
+        ),
     ]
     for t in tests:
         actual = scg.to_starlark(t.expr)
@@ -261,6 +286,7 @@ def starlark_codegen_test_suite():
         to_starlark_test,
         to_starlark_with_struct_test,
         fn_call_to_starlark_parts_test,
+        op_to_starlark_parts_test,
         new_expr_test,
         expr_to_starlark_parts_test,
     )

--- a/swiftpkg/tests/starlark_codegen_tests.bzl
+++ b/swiftpkg/tests/starlark_codegen_tests.bzl
@@ -270,6 +270,20 @@ def _expr_to_starlark_parts_test(ctx):
 """,
             msg = "operator with two strings",
         ),
+        struct(
+            expr = scg.new_expr(
+                ["hello", "goodbye"],
+                scg.new_op("+"),
+                scg.new_fn_call("glob", ["*"]),
+            ),
+            exp = """\
+[
+    "hello",
+    "goodbye",
+] + glob(["*"])\
+""",
+            msg = "operator with list and function call",
+        ),
     ]
     for t in tests:
         actual = scg.to_starlark(t.expr)

--- a/swiftpkg/tests/starlark_codegen_tests.bzl
+++ b/swiftpkg/tests/starlark_codegen_tests.bzl
@@ -211,6 +211,51 @@ foo(
 
 fn_call_to_starlark_parts_test = unittest.make(_fn_call_to_starlark_parts_test)
 
+def _new_expr_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(
+            expr = scg.new_expr("hello"),
+            exp = ["hello"],
+            msg = "a single part",
+        ),
+        struct(
+            expr = scg.new_expr("hello", 123, ["howdy"]),
+            exp = ["hello", 123, ["howdy"]],
+            msg = "multiple parts",
+        ),
+    ]
+    for t in tests:
+        actual = t.expr.parts
+        asserts.equals(env, t.exp, actual, t.msg)
+
+    return unittest.end(env)
+
+new_expr_test = unittest.make(_new_expr_test)
+
+def _expr_to_starlark_parts_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    # tests = [
+    #     struct(
+    #         expr = scg.new_expr("hello"),
+    #         exp = """\
+    # "hello"\
+    # """,
+    #         msg = "a single part",
+    #     ),
+    # ]
+    # for t in tests:
+    #     actual = scg.to_starlark(t.expr)
+    #     asserts.equals(env, t.exp, actual, t.msg)
+
+    return unittest.end(env)
+
+expr_to_starlark_parts_test = unittest.make(_expr_to_starlark_parts_test)
+
 def starlark_codegen_test_suite():
     return unittest.suite(
         "starlark_codegen_tests",
@@ -218,4 +263,6 @@ def starlark_codegen_test_suite():
         to_starlark_test,
         to_starlark_with_struct_test,
         fn_call_to_starlark_parts_test,
+        new_expr_test,
+        expr_to_starlark_parts_test,
     )

--- a/swiftpkg/tests/starlark_codegen_tests.bzl
+++ b/swiftpkg/tests/starlark_codegen_tests.bzl
@@ -100,9 +100,9 @@ def _custom_struct(name, kind, values = {}):
 def _custom_to_starlark_parts(val, indent):
     child_indent = indent + 1
     output = ["{}(\n".format(val.kind)]
-    output.extend(scg.attr("name", val.name, child_indent))
+    output.extend(scg.new_attr("name", val.name, child_indent))
     if len(val.values) > 0:
-        output.extend(scg.attr("values", val.values, child_indent))
+        output.extend(scg.new_attr("values", val.values, child_indent))
     output.append(scg.indent(indent, ")"))
     return output
 
@@ -135,10 +135,87 @@ chicken_binary(
 
 to_starlark_with_struct_test = unittest.make(_to_starlark_with_struct_test)
 
+def _fn_call_to_starlark_parts_test(ctx):
+    env = unittest.begin(ctx)
+
+    fn_call = scg.new_fn_call("foo")
+    expected = "foo()"
+    code = scg.to_starlark(fn_call)
+    asserts.equals(env, expected, code)
+
+    fn_call = scg.new_fn_call("foo", "first")
+    expected = """\
+foo("first")\
+"""
+    code = scg.to_starlark(fn_call)
+    asserts.equals(env, expected, code)
+
+    fn_call = scg.new_fn_call("foo", ["item0"])
+    expected = """\
+foo(["item0"])\
+"""
+    code = scg.to_starlark(fn_call)
+    asserts.equals(env, expected, code)
+
+    fn_call = scg.new_fn_call("foo", ["item0", "item1"])
+    expected = """\
+foo([
+    "item0",
+    "item1",
+])\
+"""
+    code = scg.to_starlark(fn_call)
+    asserts.equals(env, expected, code)
+
+    fn_call = scg.new_fn_call("foo", 123, 456)
+    expected = """\
+foo(
+    123,
+    456,
+)\
+"""
+    code = scg.to_starlark(fn_call)
+    asserts.equals(env, expected, code)
+
+    fn_call = scg.new_fn_call(
+        "foo",
+        zebra = "goodbye",
+        bar = "hello",
+    )
+    expected = """\
+foo(
+    zebra = "goodbye",
+    bar = "hello",
+)\
+"""
+    code = scg.to_starlark(fn_call)
+    asserts.equals(env, expected, code)
+
+    fn_call = scg.new_fn_call(
+        "foo",
+        "chicken",
+        zebra = "goodbye",
+        bar = "hello",
+    )
+    expected = """\
+foo(
+    "chicken",
+    zebra = "goodbye",
+    bar = "hello",
+)\
+"""
+    code = scg.to_starlark(fn_call)
+    asserts.equals(env, expected, code)
+
+    return unittest.end(env)
+
+fn_call_to_starlark_parts_test = unittest.make(_fn_call_to_starlark_parts_test)
+
 def starlark_codegen_test_suite():
     return unittest.suite(
         "starlark_codegen_tests",
         indent_str_test,
         to_starlark_test,
         to_starlark_with_struct_test,
+        fn_call_to_starlark_parts_test,
     )

--- a/swiftpkg/tests/starlark_codegen_tests.bzl
+++ b/swiftpkg/tests/starlark_codegen_tests.bzl
@@ -284,6 +284,23 @@ def _expr_to_starlark_parts_test(ctx):
 """,
             msg = "operator with list and function call",
         ),
+        struct(
+            expr = scg.new_expr(
+                ["hello", "goodbye"],
+                scg.new_op("+"),
+                ["chicken", "smidgen"],
+            ),
+            exp = """\
+[
+    "hello",
+    "goodbye",
+] + [
+    "chicken",
+    "smidgen",
+]\
+""",
+            msg = "operator with list and function call",
+        ),
     ]
     for t in tests:
         actual = scg.to_starlark(t.expr)


### PR DESCRIPTION
- Moved function call Starlark codegen to `starlark_codegen` module.
- Add missing documentation.

Related to #153 