### PR TITLE
feat: finish adding conditional build setting support

### DIFF
--- a/swiftpkg/internal/bzl_selects.bzl
+++ b/swiftpkg/internal/bzl_selects.bzl
@@ -92,12 +92,12 @@ Found a build setting condition that had no platforms or a configuration. {}\
         for c in conditions
     ]
 
-def _new_kind_handler(transform, default = None):
+def _new_kind_handler(transform = None, default = None):
     """Creates a struct that encapsulates the information needed to process a \
     condition.
 
     Args:
-        transform: A `function` that accepts a single value. The value for a
+        transform: Optional. A `function` that accepts a single value. The value for a
             condition is passed this function. The return value is used as the
             Starlark output.
         default: Optional. The value that should be added to the `select` dict
@@ -107,6 +107,8 @@ def _new_kind_handler(transform, default = None):
         A `struct` representing the information needed to process and kind
         condition.
     """
+    if transform == None:
+        transform = lambda v: v
     return struct(
         transform = transform,
         default = default,

--- a/swiftpkg/internal/bzl_selects.bzl
+++ b/swiftpkg/internal/bzl_selects.bzl
@@ -159,7 +159,6 @@ def _to_starlark(values, kind_handlers = {}):
 bzl_selects = struct(
     new_kind_handler = _new_kind_handler,
     new = _new,
-    # new_default = _new_default,
     new_from_build_setting = _new_from_build_setting,
     to_starlark = _to_starlark,
     default_condition = _bazel_select_default_condition,

--- a/swiftpkg/internal/bzl_selects.bzl
+++ b/swiftpkg/internal/bzl_selects.bzl
@@ -37,23 +37,6 @@ def _new(value, kind = None, condition = None):
         value = value,
     )
 
-# def _new_default(kind, value):
-#     """Create a condition with the condition set to Bazel's default value.
-
-#     Args:
-#         kind: A `string` that identifies the value. This comes from the SPM dump
-#             manifest. (e.g. `linkedFramework`)
-#         value: The value associated with the condition.
-
-#     Returns:
-#         A `struct` representing a Swift package manager condition.
-#     """
-#     return _new(
-#         kind = kind,
-#         condition = "//conditions:default",
-#         value = value,
-#     )
-
 def _new_from_build_setting(build_setting):
     """Create conditions from an SPM build setting.
 

--- a/swiftpkg/internal/bzl_selects.bzl
+++ b/swiftpkg/internal/bzl_selects.bzl
@@ -53,12 +53,13 @@ def _new_from_build_setting(build_setting):
             for v in build_setting.values
         ]
 
-    if bsc.platforms != None and bsc.configuration != None:
+    platforms_len = len(bsc.platforms)
+    if platforms_len > 0 and bsc.configuration != None:
         conditions = [
             spm_platform_configurations.label(p, bsc.configuration)
             for p in bsc.platforms
         ]
-    elif bsc.platforms != None:
+    elif platforms_len > 0:
         conditions = [spm_platforms.label(p) for p in bsc.platforms]
     elif bsc.configuration != None:
         conditions = [spm_configurations.label(bsc.configuration)]

--- a/swiftpkg/internal/bzl_selects.bzl
+++ b/swiftpkg/internal/bzl_selects.bzl
@@ -37,24 +37,22 @@ def _new(value, kind = None, condition = None):
         value = value,
     )
 
-def _new_default(kind, value):
-    """Create a condition with the condition set to Bazel's default value.
+# def _new_default(kind, value):
+#     """Create a condition with the condition set to Bazel's default value.
 
-    Args:
-        kind: A `string` that identifies the value. This comes from the SPM dump
-            manifest. (e.g. `linkedFramework`)
-        value: The value associated with the condition.
+#     Args:
+#         kind: A `string` that identifies the value. This comes from the SPM dump
+#             manifest. (e.g. `linkedFramework`)
+#         value: The value associated with the condition.
 
-    Returns:
-        A `struct` representing a Swift package manager condition.
-    """
-    return _new(
-        kind = kind,
-        condition = "//conditions:default",
-        value = value,
-    )
-
-# GH153: Finish conditional support.
+#     Returns:
+#         A `struct` representing a Swift package manager condition.
+#     """
+#     return _new(
+#         kind = kind,
+#         condition = "//conditions:default",
+#         value = value,
+#     )
 
 def _new_from_build_setting(build_setting):
     """Create conditions from an SPM build setting.
@@ -92,7 +90,7 @@ Found a build setting condition that had no platforms or a configuration. {}\
         for c in conditions
     ]
 
-def _new_kind_handler(transform = None, default = None):
+def _new_kind_handler(transform = None, default = []):
     """Creates a struct that encapsulates the information needed to process a \
     condition.
 
@@ -101,7 +99,7 @@ def _new_kind_handler(transform = None, default = None):
             condition is passed this function. The return value is used as the
             Starlark output.
         default: Optional. The value that should be added to the `select` dict
-            for the kind.
+            for the kind. Defaults to `[]`.
 
     Returns:
         A `struct` representing the information needed to process and kind
@@ -178,7 +176,7 @@ def _to_starlark(values, kind_handlers = {}):
 bzl_selects = struct(
     new_kind_handler = _new_kind_handler,
     new = _new,
-    new_default = _new_default,
+    # new_default = _new_default,
     new_from_build_setting = _new_from_build_setting,
     to_starlark = _to_starlark,
     default_condition = _bazel_select_default_condition,

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -742,19 +742,25 @@ def _new_clang_settings(build_settings):
     """
     defines = []
     hdr_srch_paths = []
+    unsafe_flags = []
     for bs in build_settings:
         if bs.kind == build_setting_kinds.define:
             defines.append(bs)
         elif bs.kind == build_setting_kinds.header_search_path:
             hdr_srch_paths.append(bs)
+        elif bs.kind == build_setting_kinds.unsafe_flags:
+            unsafe_flags.append(bs)
         else:
             # We do not recognize the setting.
             pass
-    if len(defines) == 0 and len(hdr_srch_paths) == 0:
+    if len(defines) == 0 and \
+       len(hdr_srch_paths) == 0 and \
+       len(unsafe_flags) == 0:
         return None
     return struct(
         defines = defines,
         hdr_srch_paths = hdr_srch_paths,
+        unsafe_flags = unsafe_flags,
     )
 
 def _new_swift_settings(build_settings):
@@ -768,16 +774,20 @@ def _new_swift_settings(build_settings):
         A `struct` representing the Swift settings.
     """
     defines = []
+    unsafe_flags = []
     for bs in build_settings:
         if bs.kind == build_setting_kinds.define:
             defines.append(bs)
+        elif bs.kind == build_setting_kinds.unsafe_flags:
+            unsafe_flags.append(bs)
         else:
             # We do not recognize the setting.
             pass
-    if len(defines) == 0:
+    if len(defines) == 0 and len(unsafe_flags) == 0:
         return None
     return struct(
         defines = defines,
+        unsafe_flags = unsafe_flags,
     )
 
 def _new_linker_settings(build_settings):
@@ -863,6 +873,7 @@ build_setting_kinds = struct(
     header_search_path = "headerSearchPath",
     linked_framework = "linkedFramework",
     linked_library = "linkedLibrary",
+    unsafe_flags = "unsafeFlags",
 )
 
 # MARK: - API Definition

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -1,5 +1,6 @@
 """API for creating and loading Swift package information."""
 
+load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "lists")
 load(
     "//config_settings/spm/configuration:configurations.bzl",
     spm_configurations = "configurations",
@@ -242,7 +243,8 @@ def _new_build_settings_from_json(dump_map):
     return [
         _new_build_setting(
             kind = build_setting_kind,
-            values = kind_type_values.values(),
+            # Some settings (e.g. unsafeFlags) are written as a list.
+            values = lists.flatten(kind_type_values.values()),
             condition = condition,
         )
         for (build_setting_kind, kind_type_values) in kind_map.items()

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -743,9 +743,9 @@ def _new_clang_settings(build_settings):
     defines = []
     hdr_srch_paths = []
     for bs in build_settings:
-        if bs.kind == "define":
+        if bs.kind == build_setting_kinds.define:
             defines.append(bs)
-        elif bs.kind == "headerSearchPath":
+        elif bs.kind == build_setting_kinds.header_search_path:
             hdr_srch_paths.append(bs)
         else:
             # We do not recognize the setting.
@@ -769,7 +769,7 @@ def _new_swift_settings(build_settings):
     """
     defines = []
     for bs in build_settings:
-        if bs.kind == "define":
+        if bs.kind == build_setting_kinds.define:
             defines.append(bs)
         else:
             # We do not recognize the setting.
@@ -793,9 +793,9 @@ def _new_linker_settings(build_settings):
     linked_libraries = []
     linked_frameworks = []
     for bs in build_settings:
-        if bs.kind == "linkedLibrary":
+        if bs.kind == build_setting_kinds.linked_library:
             linked_libraries.append(bs)
-        elif bs.kind == "linkedFramework":
+        elif bs.kind == build_setting_kinds.linked_framework:
             linked_frameworks.append(bs)
         else:
             # We do not recognize the setting.
@@ -856,6 +856,13 @@ library_type_kinds = struct(
     dynamic = "dynamic",
     static = "static",
     all_values = ["automatic", "dynamic", "static"],
+)
+
+build_setting_kinds = struct(
+    define = "define",
+    header_search_path = "headerSearchPath",
+    linked_framework = "linkedFramework",
+    linked_library = "linkedLibrary",
 )
 
 # MARK: - API Definition

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -681,7 +681,7 @@ def _new_target(
 
 # MARK: - Build Settings
 
-def _new_build_setting_condition(platforms = None, configuration = None):
+def _new_build_setting_condition(platforms = [], configuration = None):
     """Create a build setting condition.
 
     Args:
@@ -692,15 +692,15 @@ def _new_build_setting_condition(platforms = None, configuration = None):
     Returns:
         A `struct` representing build setting condition.
     """
-    if platforms == None and configuration == None:
+    if platforms == [] and configuration == None:
         return None
-    if platforms != None:
-        for platform in platforms:
-            validations.in_list(
-                spm_platforms.all_values,
-                platform,
-                "Unrecognized platform. platform:",
-            )
+
+    for platform in platforms:
+        validations.in_list(
+            spm_platforms.all_values,
+            platform,
+            "Unrecognized platform. platform:",
+        )
 
     if configuration != None:
         validations.in_list(

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -603,6 +603,7 @@ skylib_build_test_load_stmt = load_statements.new(
 swiftpkg_build_files = struct(
     new_for_target = _new_for_target,
     new_for_products = _new_for_products,
+    new_for_product = _new_for_product,
 )
 
 apple_kinds = struct(

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -48,6 +48,10 @@ def _swift_target_build_file(repository_ctx, pkg_ctx, target):
 
     # GH046: Support plugins.
 
+    # TODO(chuck): Add conditional support for Swift settings.
+
+    # TODO(chuck): Add unsafe_flags
+
     # The rules_swift code links in developer libraries if the rule is marked testonly.
     # https://github.com/bazelbuild/rules_swift/blob/master/swift/internal/compiling.bzl#L1312-L1319
     is_test = _imports_xctest(repository_ctx, pkg_ctx, target)
@@ -222,16 +226,6 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
                 for bs in target.clang_settings.defines
             ]))
         if len(target.clang_settings.hdr_srch_paths) > 0:
-            # # GH153: Support conditional
-            # hdr_srch_paths = lists.flatten([
-            #     bs.values
-            #     for bs in target.clang_settings.hdr_srch_paths
-            # ])
-            # local_includes.extend([
-            #     paths.join(target.path, p)
-            #     for p in hdr_srch_paths
-            # ])
-
             # Need to convert the headerSearchPaths to be relative to the
             # target path. We also do not want to lose any conditions that may
             # be attached.
@@ -250,10 +244,11 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
                 bzl_selects.new_from_build_setting(bs)
                 for bs in hsp_bss
             ]))
-            # local_includes.extend(lists.flatten([
-            #     bzl_selects.new_from_build_setting(bs)
-            #     for bs in target.clang_settings.hdr_srch_paths
-            # ]))
+        if len(target.clang_settings.unsafe_flags) > 0:
+            copts.extend(lists.flatten([
+                bzl_selects.new_from_build_setting(bs)
+                for bs in target.clang_settings.unsafe_flags
+            ]))
 
     if target.linker_settings != None:
         if len(target.linker_settings.linked_libraries) > 0:

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -214,9 +214,10 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         local_includes.extend(organized_files.private_includes)
     if target.clang_settings != None:
         if len(target.clang_settings.defines) > 0:
-            # GH153: Support conditional
-            for bs in target.clang_settings.defines:
-                defines.extend(bs.values)
+            defines.extend(lists.flatten([
+                bzl_selects.new_from_build_setting(bs)
+                for bs in target.clang_settings.defines
+            ]))
         if len(target.clang_settings.hdr_srch_paths) > 0:
             # GH153: Support conditional
             hdr_srch_paths = lists.flatten([

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -268,28 +268,14 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             ]))
 
     if len(local_includes) > 0:
-        # # The `includes` attribute adds includes as -isystem which propagates
-        # # to cc_XXX that depend upon the library. Providing includes as -I only
-        # # provides the includes for this target.
-        # # https://bazel.build/reference/be/c-cpp#cc_library.includes
-        # copts.extend([
-        #     "-I{}".format(paths.normalize(paths.join(ext_repo_path, inc)))
-        #     for inc in sets.to_list(sets.make(local_includes))
-        # ])
-
         copts.extend(local_includes)
 
         # If the target path is not everything (i.e., dot), then check for
         # local includes that are outside the target path. We need to add them
         # to the srcs so that they can be found.
         if target.path != ".":
-            # # Ensure that any header files that are outside of the target path are
-            # # included in the srcs.
-            # for li in local_includes:
-            #     normalized_li = paths.normalize(li)
-            #     if clang_files.is_under_path(normalized_li, target.path):
-            #         continue
-            #     extra_hdr_dirs.append(normalized_li)
+            # Ensure that any header files that are outside of the target path are
+            # included in the srcs.
             local_include_values = []
             for li in local_includes:
                 li_type = type(li)
@@ -352,11 +338,6 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             kind_handlers = {
                 _condition_kinds.header_search_path: bzl_selects.new_kind_handler(
                     transform = local_includes_transform,
-                    # # Need to convert the headerSearchPaths to be relative to
-                    # # the target path.
-                    # transform = lambda p: local_includes_transform(
-                    #     paths.join(target.path, p),
-                    # ),
                 ),
                 _condition_kinds.private_includes: bzl_selects.new_kind_handler(
                     transform = local_includes_transform,

--- a/swiftpkg/tests/bzl_selects_tests.bzl
+++ b/swiftpkg/tests/bzl_selects_tests.bzl
@@ -276,6 +276,40 @@ def _to_starlark_test(ctx):
 
 to_starlark_test = unittest.make(_to_starlark_test)
 
+def _new_kind_handler_test(ctx):
+    env = unittest.begin(ctx)
+
+    value = "foo"
+
+    tests = [
+        struct(
+            msg = "no parameters",
+            transform = None,
+            default = None,
+            exp_tx = "foo",
+            exp_def = None,
+        ),
+        struct(
+            msg = "with parameters",
+            transform = lambda v: v + "bar",
+            default = [],
+            exp_tx = "foobar",
+            exp_def = [],
+        ),
+    ]
+    for t in tests:
+        kh = bzl_selects.new_kind_handler(
+            transform = t.transform,
+            default = t.default,
+        )
+        actual_tx = kh.transform(value)
+        asserts.equals(env, t.exp_tx, actual_tx, t.msg + " transform")
+        asserts.equals(env, t.exp_def, kh.default, t.msg + " default")
+
+    return unittest.end(env)
+
+new_kind_handler_test = unittest.make(_new_kind_handler_test)
+
 def bzl_selects_test_suite():
     return unittest.suite(
         "bzl_selects_tests",
@@ -283,4 +317,5 @@ def bzl_selects_test_suite():
         new_default_test,
         new_from_build_setting_test,
         to_starlark_test,
+        new_kind_handler_test,
     )

--- a/swiftpkg/tests/bzl_selects_tests.bzl
+++ b/swiftpkg/tests/bzl_selects_tests.bzl
@@ -33,24 +33,6 @@ def _new_test(ctx):
 
 new_test = unittest.make(_new_test)
 
-def _new_default_test(ctx):
-    env = unittest.begin(ctx)
-
-    actual = bzl_selects.new_default(
-        kind = "platform_types",
-        value = [],
-    )
-    expected = bzl_selects.new(
-        kind = "platform_types",
-        condition = "//conditions:default",
-        value = [],
-    )
-    asserts.equals(env, expected, actual)
-
-    return unittest.end(env)
-
-new_default_test = unittest.make(_new_default_test)
-
 def _new_from_build_setting_test(ctx):
     env = unittest.begin(ctx)
 
@@ -318,7 +300,6 @@ def bzl_selects_test_suite():
     return unittest.suite(
         "bzl_selects_tests",
         new_test,
-        new_default_test,
         new_from_build_setting_test,
         to_starlark_test,
         new_kind_handler_test,

--- a/swiftpkg/tests/bzl_selects_tests.bzl
+++ b/swiftpkg/tests/bzl_selects_tests.bzl
@@ -215,7 +215,11 @@ def _to_starlark_test(ctx):
         ),
         struct(
             msg = "one with condition, one without condition, no default",
-            khs = {},
+            khs = {
+                # If a default is not specified, it is assumed to be [].
+                # Hence, we need to specify None.
+                "linkedLibrary": bzl_selects.new_kind_handler(default = None),
+            },
             vals = [
                 bzl_selects.new(
                     value = "sqlite3",

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -11,7 +11,6 @@ load(
     "swiftpkg_build_files",
 )
 
-# This is a simplified version of SwiftLint.
 _pkg_info = pkginfos.new(
     name = "SwiftLint",
     path = "/path/to/swiftlint",
@@ -99,15 +98,16 @@ _pkg_info = pkginfos.new(
 _deps_index_json = """
 {
   "modules": [
-    {"name": "swiftlint", "c99name": "swiftlint", "label": "@realm_swiftlint//:Source_swiftlint"},
-    {"name": "SwiftLintFramework", "c99name": "SwiftLintFramework", "label": "@realm_swiftlint//:Source_SwiftLintFramework"},
-    {"name": "SwiftLintFrameworkTests", "c99name": "SwiftLintFrameworkTests", "label": "@realm_swiftlint//:Source_SwiftLintFrameworkTests"}
+    {"name": "swiftlint", "c99name": "swiftlint", "label": "@swiftpkg_swiftlint//:Source_swiftlint"},
+    {"name": "SwiftLintFramework", "c99name": "SwiftLintFramework", "label": "@swiftpkg_swiftlint//:Source_SwiftLintFramework"},
+    {"name": "SwiftLintFrameworkTests", "c99name": "SwiftLintFrameworkTests", "label": "@swiftpkg_swiftlint//:Source_SwiftLintFrameworkTests"}
   ],
-  "products": {}
+  "products": [
+  ]
 }
 """
 
-_repo_name = "@realm_swiftlint"
+_repo_name = "@swiftpkg_swiftlint"
 
 _pkg_ctx = pkg_ctxs.new(
     pkg_info = _pkg_info,
@@ -158,7 +158,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 swift_library(
     name = "Source_swiftlint",
     defines = ["SWIFT_PACKAGE"],
-    deps = ["@realm_swiftlint//:Source_SwiftLintFramework"],
+    deps = ["@swiftpkg_swiftlint//:Source_SwiftLintFramework"],
     module_name = "swiftlint",
     srcs = [
         "Source/swiftlint/Commands/SwiftLint.swift",
@@ -177,7 +177,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
 swift_test(
     name = "Tests_SwiftLintFrameworkTests",
     defines = ["SWIFT_PACKAGE"],
-    deps = ["@realm_swiftlint//:Source_SwiftLintFramework"],
+    deps = ["@swiftpkg_swiftlint//:Source_SwiftLintFramework"],
     module_name = "SwiftLintFrameworkTests",
     srcs = ["Tests/SwiftLintFrameworkTests/SwiftLintFrameworkTests.swift"],
     visibility = ["//visibility:public"],
@@ -208,7 +208,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 
 swift_binary(
     name = "swiftlint",
-    deps = ["@realm_swiftlint//:Source_swiftlint"],
+    deps = ["@swiftpkg_swiftlint//:Source_swiftlint"],
     visibility = ["//visibility:public"],
 )
 """,
@@ -221,7 +221,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 build_test(
     name = "SwiftLintFrameworkBuildTest",
-    targets = ["@realm_swiftlint//:Source_SwiftLintFramework"],
+    targets = ["@swiftpkg_swiftlint//:Source_SwiftLintFramework"],
     visibility = ["//visibility:public"],
 )
 """,


### PR DESCRIPTION
- Add conditional support for `headerSearchPaths`.
- Add conditional support for `unsafeFlags`.
- Refactor tests for `swiftpkg_build_files`.

Related to #153.