### PR TITLE
fix: ensure `bzl_selects.to_starlark` collects condition values

### DIFF
--- a/config_settings/spm/platform/platforms.bzl
+++ b/config_settings/spm/platform/platforms.bzl
@@ -48,6 +48,7 @@ _PLATFORM_INFOS = [
 ] + [
     # Treat `maccatalyst` as an alias of sorts for macos. This will be handled
     # in the `platforms.label` function.
+    _platform_info(spm = "maccatalyst", bzl = None, os = None),
     # Not sure how to map driverkit
     _platform_info(spm = "driverkit", bzl = None, os = None),
 ]

--- a/config_settings/spm/platform/platforms.bzl
+++ b/config_settings/spm/platform/platforms.bzl
@@ -46,7 +46,8 @@ _PLATFORM_INFOS = [
     _platform_info(spm = p, bzl = None, os = p)
     for p in _NON_APPLE_PLATFORMS
 ] + [
-    _platform_info(spm = "maccatalyst", bzl = "macos", os = "macos"),
+    # Treat `maccatalyst` as an alias of sorts for macos. This will be handled
+    # in the `platforms.label` function.
     # Not sure how to map driverkit
     _platform_info(spm = "driverkit", bzl = None, os = None),
 ]
@@ -60,6 +61,8 @@ def _label(name):
     Returns:
         The condition label as a `string`.
     """
+    if name == "maccatalyst":
+        name = "macos"
     return "@cgrindel_swift_bazel//config_settings/spm/platform:{}".format(name)
 
 platforms = struct(

--- a/swiftpkg/internal/bzl_selects.bzl
+++ b/swiftpkg/internal/bzl_selects.bzl
@@ -162,8 +162,11 @@ def _to_starlark(values, kind_handlers = {}):
         kind_handler = kind_handlers.get(v.kind, _noop_kind_handler)
         tv = lists.flatten(kind_handler.transform(v.value))
         if v.condition != None:
+            # Collect all of the values associted with a condition.
             select_dict = selects_by_kind.get(v.kind, {})
-            select_dict[v.condition] = tv
+            condition_values = select_dict.get(v.condition, [])
+            condition_values.extend(tv)
+            select_dict[v.condition] = condition_values
             selects_by_kind[v.kind] = select_dict
         else:
             no_condition_results.extend(tv)

--- a/swiftpkg/internal/pkginfo_target_deps.bzl
+++ b/swiftpkg/internal/pkginfo_target_deps.bzl
@@ -21,7 +21,7 @@ def make_pkginfo_target_deps(bazel_labels):
                 `pkginfos.new_target_dependency`.
 
         Returns:
-            A `list` of `struct` values as returned by `conditional_labels.new`
+            A `list` of `struct` values as returned by `bzl_selects.new`
             representing the labels for the target dependency.
         """
         if target_dep.by_name:

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -427,6 +427,7 @@ def _apple_dynamic_xcframework_import_build_file(target):
             kind = apple_kinds.dynamic_xcframework_import,
             name = pkginfo_targets.bazel_label_name(target),
             attrs = {
+                "visibility": ["//visibility:public"],
                 "xcframework_imports": glob,
             },
         ),

--- a/swiftpkg/tests/bzl_selects_tests.bzl
+++ b/swiftpkg/tests/bzl_selects_tests.bzl
@@ -143,7 +143,7 @@ def _to_starlark_test(ctx):
         struct(
             msg = "string values",
             khs = {},
-            vals = ["first", "second"],
+            vals = ["first", "second", "first"],
             exp = """\
 [
     "first",
@@ -267,6 +267,11 @@ def _to_starlark_test(ctx):
                 ),
                 bzl_selects.new(
                     value = "c",
+                    kind = "mykind",
+                    condition = "//myconditions:alpha",
+                ),
+                bzl_selects.new(
+                    value = "a",
                     kind = "mykind",
                     condition = "//myconditions:alpha",
                 ),

--- a/swiftpkg/tests/bzl_selects_tests.bzl
+++ b/swiftpkg/tests/bzl_selects_tests.bzl
@@ -251,6 +251,37 @@ def _to_starlark_test(ctx):
 })\
 """,
         ),
+        struct(
+            msg = "multiple of the same condition",
+            khs = {},
+            vals = [
+                bzl_selects.new(
+                    value = "a",
+                    kind = "mykind",
+                    condition = "//myconditions:alpha",
+                ),
+                bzl_selects.new(
+                    value = "b",
+                    kind = "mykind",
+                    condition = "//myconditions:beta",
+                ),
+                bzl_selects.new(
+                    value = "c",
+                    kind = "mykind",
+                    condition = "//myconditions:alpha",
+                ),
+            ],
+            exp = """\
+select({
+    "//myconditions:alpha": [
+        "a",
+        "c",
+    ],
+    "//myconditions:beta": ["b"],
+    "//conditions:default": [],
+})\
+""",
+        ),
     ]
     for t in tests:
         actual = scg.to_starlark(


### PR DESCRIPTION
- Values for the same condition can be found in multiple entries. Update `bzl_selects.to_starlark` to collect the values.
- Ensure generated `apple_dynamic_xcframework_import` declarations are publicly visible.

Related to #153