### PR TITLE
chore: upgrade bazel-starlib to 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ development inside a Bazel workspace.
   * [Mac OS](#mac-os)
   * [Linux](#linux)
 * [Quickstart](#quickstart)
-  * [1\. Configure your workspace to use swift\_bazel \.](https://github.com/cgrindel/swift_bazel)
+  * [1\. Configure your workspace to use <a href="https://github\.com/cgrindel/swift\_bazel">swift\_bazel</a>\.](#1-configure-your-workspace-to-use-swift_bazel)
   * [2\. Create a minimal Package\.swift file\.](#2-create-a-minimal-packageswift-file)
   * [3\. Add Gazelle targets to BUILD\.bazel at the root of your workspace\.](#3-add-gazelle-targets-to-buildbazel-at-the-root-of-your-workspace)
   * [4\. Resolve the external dependencies for your project\.](#4-resolve-the-external-dependencies-for-your-project)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,6 +31,10 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 load("//:go_deps.bzl", "swift_bazel_go_dependencies")
 
+# Workaround for missing strict deps error as described here:
+# https://github.com/bazelbuild/bazel-gazelle/issues/1217#issuecomment-1152236735
+# gazelle:repository go_repository name=in_gopkg_alecthomas_kingpin_v2 importpath=gopkg.in/alecthomas/kingpin.v2
+
 # gazelle:repository_macro go_deps.bzl%swift_bazel_go_dependencies
 swift_bazel_go_dependencies()
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -40,9 +40,9 @@ def swift_bazel_dependencies():
     maybe(
         http_archive,
         name = "cgrindel_bazel_starlib",
-        sha256 = "b4c92b66569c3371c08ef359883600c46bd51951e453cf12daa3b062ebea368a",
+        sha256 = "2c21a982f4928dafed4a4229ec25c656c56fdb98d17fb7e79928b60f828fbdd7",
         urls = [
-            "https://github.com/cgrindel/bazel-starlib/releases/download/v0.12.0/bazel-starlib.v0.12.0.tar.gz",
+            "https://github.com/cgrindel/bazel-starlib/releases/download/v0.12.1/bazel-starlib.v0.12.1.tar.gz",
         ],
     )
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,10 +7,10 @@
 * [Why split the implementation between Go and Starlark?](#why-split-the-implementation-between-go-and-starlark)
   * [How does the Gazelle plugin for Go handle this?](#how-does-the-gazelle-plugin-for-go-handle-this)
 * [Is the same build file generation logic used for the Go/Gazelle and Starlark implementations?](#is-the-same-build-file-generation-logic-used-for-the-gogazelle-and-starlark-implementations)
-* [Does this replace rules\_spm ?](https://github.com/cgrindel/rules_spm/)
-* [Can I migrate from rules\_spm to swift\_bazel ?](https://github.com/cgrindel/rules_spm/)
+* [Does this replace <a href="https://github\.com/cgrindel/rules\_spm/">rules\_spm</a>?](#does-this-replace-rules_spm)
+* [Can I migrate from <a href="https://github\.com/cgrindel/rules\_spm/">rules\_spm</a> to swift\_bazel?](#can-i-migrate-from-rules_spm-to-swift_bazel)
 * [Can I just manage my external Swift packages and not generate Bazel build files for my project?](#can-i-just-manage-my-external-swift-packages-and-not-generate-bazel-build-files-for-my-project)
-* [After running //:swift\_update\_pkgs , I see a \.build directory\. What is it? Do I need it?](#after-running-swift_update_pkgs-i-see-a-build-directory-what-is-it-do-i-need-it)
+* [After running //:swift\_update\_pkgs, I see a \.build directory\. What is it? Do I need it?](#after-running-swift_update_pkgs-i-see-a-build-directory-what-is-it-do-i-need-it)
 * [Does the Gazelle plugin run Swift package manager with every execution?](#does-the-gazelle-plugin-run-swift-package-manager-with-every-execution)
 * [Can I store the Swift dependency files in a sub\-package (i\.e\., not in the root of the workspace)?](#can-i-store-the-swift-dependency-files-in-a-sub-package-ie-not-in-the-root-of-the-workspace)
 <!-- MARKDOWN TOC: END -->


### PR DESCRIPTION
- Upgrade bazel-skylib to 0.12.1. 
- Add workaround for missing strict dep when building markdown toc generator.

The workaround should fix the strict dep failure seen in CI runs for #205.