### PR TITLE
feat: add resolution logger to Gazelle extension

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -154,6 +154,7 @@ filegroup(
         "//gazelle:all_files",
         "//gazelle/internal/jsonutils:all_files",
         "//gazelle/internal/pathdistance:all_files",
+        "//gazelle/internal/reslog:all_files",
         "//gazelle/internal/spdesc:all_files",
         "//gazelle/internal/spdump:all_files",
         "//gazelle/internal/spreso:all_files",

--- a/examples/pkg_manifest_minimal/do_test
+++ b/examples/pkg_manifest_minimal/do_test
@@ -27,3 +27,8 @@ assert_match "Good evening, Jim!" "${output}"
 
 # Buid and run the SwiftFormat alias
 bazel run //:swiftformat -- --version
+
+# Generate a resolution log file
+res_log_path="${script_dir}/res_log.yml"
+bazel run //:update_build_files --  "--resolution_log=${res_log_path}"
+[[ -e "${res_log_path}" ]] || (echo >&2 "Expected to find a resolution log file at ${res_log_path}" && exit 1)

--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
     importpath = "github.com/cgrindel/swift_bazel/gazelle",
     visibility = ["//visibility:public"],
     deps = [
+        "//gazelle/internal/reslog",
         "//gazelle/internal/spreso",
         "//gazelle/internal/stringslices",
         "//gazelle/internal/swift",

--- a/gazelle/internal/reslog/BUILD.bazel
+++ b/gazelle/internal/reslog/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "@bazel_gazelle//resolve:go_default_library",
         "@bazel_gazelle//rule:go_default_library",
         "@com_github_deckarep_golang_set_v2//:golang-set",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_x_exp//slices",
     ],
 )

--- a/gazelle/internal/reslog/BUILD.bazel
+++ b/gazelle/internal/reslog/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "reslog",
+    srcs = [
+        "resolution_logger.go",
+        "rule_resolution.go",
+    ],
+    importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/reslog",
+    visibility = ["//gazelle:__subpackages__"],
+    deps = [
+        "//gazelle/internal/swift",
+        "@bazel_gazelle//resolve:go_default_library",
+        "@bazel_gazelle//rule:go_default_library",
+        "@com_github_deckarep_golang_set_v2//:golang-set",
+    ],
+)
+
+go_test(
+    name = "reslog_test",
+    srcs = [
+        "resolution_logger_test.go",
+        "rule_resolution_test.go",
+    ],
+    deps = [
+        ":reslog",
+        "//gazelle/internal/swift",
+        "//gazelle/internal/swiftpkg",
+        "@bazel_gazelle//label:go_default_library",
+        "@bazel_gazelle//resolve:go_default_library",
+        "@bazel_gazelle//rule:go_default_library",
+        "@com_github_stretchr_testify//assert",
+    ],
+)
+
+bzlformat_pkg(name = "bzlformat")

--- a/gazelle/internal/reslog/BUILD.bazel
+++ b/gazelle/internal/reslog/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//gazelle:__subpackages__"],
     deps = [
         "//gazelle/internal/swift",
+        "@bazel_gazelle//label:go_default_library",
         "@bazel_gazelle//resolve:go_default_library",
         "@bazel_gazelle//rule:go_default_library",
         "@com_github_deckarep_golang_set_v2//:golang-set",

--- a/gazelle/internal/reslog/BUILD.bazel
+++ b/gazelle/internal/reslog/BUILD.bazel
@@ -39,3 +39,11 @@ go_test(
 )
 
 bzlformat_pkg(name = "bzlformat")
+
+# MARK: - Integration Test
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["*"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/gazelle/internal/reslog/BUILD.bazel
+++ b/gazelle/internal/reslog/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "resolution_logger.go",
         "rule_resolution.go",
+        "rule_resolution_summary.go",
     ],
     importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/reslog",
     visibility = ["//gazelle:__subpackages__"],
@@ -14,6 +15,7 @@ go_library(
         "@bazel_gazelle//resolve:go_default_library",
         "@bazel_gazelle//rule:go_default_library",
         "@com_github_deckarep_golang_set_v2//:golang-set",
+        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/gazelle/internal/reslog/resolution_logger.go
+++ b/gazelle/internal/reslog/resolution_logger.go
@@ -46,7 +46,7 @@ func (wl *writerLogger) Flush() error {
 
 // Noop Logger
 
-func NoopLogger() ResolutionLogger {
+func NewNoopLogger() ResolutionLogger {
 	return &noopLogger{}
 }
 

--- a/gazelle/internal/reslog/resolution_logger.go
+++ b/gazelle/internal/reslog/resolution_logger.go
@@ -34,6 +34,10 @@ func (wl *writerLogger) Log(rr *RuleResolution) error {
 	if err != nil {
 		return err
 	}
+	// Write a document separator
+	if _, err = wl.writer.WriteString("---\n"); err != nil {
+		return err
+	}
 	if _, err = wl.writer.Write(b); err != nil {
 		return err
 	}

--- a/gazelle/internal/reslog/resolution_logger.go
+++ b/gazelle/internal/reslog/resolution_logger.go
@@ -1,0 +1,57 @@
+package reslog
+
+import (
+	"os"
+)
+
+// ResolutionLogger
+
+type ResolutionLogger interface {
+	// Log the rule resolution
+	Log(rr *RuleResolution) error
+
+	// Close the log
+	Close() error
+}
+
+// LogToFile
+
+func LogToFile(path string) (ResolutionLogger, error) {
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	return &fileLogger{
+		file: file,
+	}, nil
+}
+
+type fileLogger struct {
+	file *os.File
+}
+
+func (fl *fileLogger) Log(rr *RuleResolution) error {
+	// TODO(chuck): IMPLEMENT ME!
+	return nil
+}
+
+func (fl *fileLogger) Close() error {
+	return fl.file.Close()
+}
+
+// Noop Logger
+
+func NoopLogger() ResolutionLogger {
+	return &noopLogger{}
+}
+
+type noopLogger struct{}
+
+func (nl *noopLogger) Log(rr *RuleResolution) error {
+	// Do nothing
+	return nil
+}
+
+func (nl *noopLogger) Close() error {
+	return nil
+}

--- a/gazelle/internal/reslog/resolution_logger_test.go
+++ b/gazelle/internal/reslog/resolution_logger_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/reslog"
 	"github.com/stretchr/testify/assert"
@@ -13,24 +14,41 @@ func TestWriterLogger(t *testing.T) {
 	var b bytes.Buffer
 	var err error
 	wl := reslog.NewLoggerFromWriter(&b)
-	err = wl.Log(reslog.NewRuleResolution(rule.NewRule("swift_library", "Foo"), []string{"Bar", "Baz"}))
+	err = wl.Log(reslog.NewRuleResolution(
+		label.New("", "", "Foo"),
+		rule.NewRule("swift_library", "Foo"),
+		[]string{"Bar", "Baz"},
+	))
 	assert.NoError(t, err)
-	err = wl.Log(reslog.NewRuleResolution(rule.NewRule("swift_library", "Bar"), []string{"Baz"}))
+	err = wl.Log(reslog.NewRuleResolution(
+		label.New("", "", "Bar"),
+		rule.NewRule("swift_library", "Bar"),
+		[]string{"Baz"},
+	))
 	assert.NoError(t, err)
 	err = wl.Flush()
 	assert.NoError(t, err)
 
 	actual := b.String()
-	assert.Contains(t, actual, "name: Foo")
-	assert.Contains(t, actual, "name: Bar")
+	assert.Contains(t, actual, "---")
+	assert.Contains(t, actual, "name: //:Foo")
+	assert.Contains(t, actual, "name: //:Bar")
 }
 
 func TestNoopLogger(t *testing.T) {
 	var err error
 	nl := reslog.NewNoopLogger()
-	err = nl.Log(reslog.NewRuleResolution(rule.NewRule("swift_library", "Foo"), []string{"Bar", "Baz"}))
+	err = nl.Log(reslog.NewRuleResolution(
+		label.New("", "", "Foo"),
+		rule.NewRule("swift_library", "Foo"),
+		[]string{"Bar", "Baz"},
+	))
 	assert.NoError(t, err)
-	err = nl.Log(reslog.NewRuleResolution(rule.NewRule("swift_library", "Bar"), []string{"Baz"}))
+	err = nl.Log(reslog.NewRuleResolution(
+		label.New("", "", "Bar"),
+		rule.NewRule("swift_library", "Bar"),
+		[]string{"Baz"},
+	))
 	assert.NoError(t, err)
 	err = nl.Flush()
 	assert.NoError(t, err)

--- a/gazelle/internal/reslog/resolution_logger_test.go
+++ b/gazelle/internal/reslog/resolution_logger_test.go
@@ -1,9 +1,28 @@
 package reslog_test
 
-import "testing"
+import (
+	"bytes"
+	"testing"
 
-func TestLogToFile(t *testing.T) {
-	t.Error("IMPLEMENT ME!")
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/reslog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriterLogger(t *testing.T) {
+	var b bytes.Buffer
+	var err error
+	wl := reslog.NewLoggerFromWriter(&b)
+	err = wl.Log(reslog.NewRuleResolution(rule.NewRule("swift_library", "Foo"), []string{"Bar", "Baz"}))
+	assert.NoError(t, err)
+	err = wl.Log(reslog.NewRuleResolution(rule.NewRule("swift_library", "Bar"), []string{"Baz"}))
+	assert.NoError(t, err)
+	err = wl.Flush()
+	assert.NoError(t, err)
+
+	actual := b.String()
+	assert.Contains(t, actual, "name: Foo")
+	assert.Contains(t, actual, "name: Bar")
 }
 
 func TestNoopLogger(t *testing.T) {

--- a/gazelle/internal/reslog/resolution_logger_test.go
+++ b/gazelle/internal/reslog/resolution_logger_test.go
@@ -26,5 +26,12 @@ func TestWriterLogger(t *testing.T) {
 }
 
 func TestNoopLogger(t *testing.T) {
-	t.Error("IMPLEMENT ME!")
+	var err error
+	nl := reslog.NewNoopLogger()
+	err = nl.Log(reslog.NewRuleResolution(rule.NewRule("swift_library", "Foo"), []string{"Bar", "Baz"}))
+	assert.NoError(t, err)
+	err = nl.Log(reslog.NewRuleResolution(rule.NewRule("swift_library", "Bar"), []string{"Baz"}))
+	assert.NoError(t, err)
+	err = nl.Flush()
+	assert.NoError(t, err)
 }

--- a/gazelle/internal/reslog/resolution_logger_test.go
+++ b/gazelle/internal/reslog/resolution_logger_test.go
@@ -1,0 +1,11 @@
+package reslog_test
+
+import "testing"
+
+func TestLogToFile(t *testing.T) {
+	t.Error("IMPLEMENT ME!")
+}
+
+func TestNoopLogger(t *testing.T) {
+	t.Error("IMPLEMENT ME!")
+}

--- a/gazelle/internal/reslog/rule_resolution.go
+++ b/gazelle/internal/reslog/rule_resolution.go
@@ -49,8 +49,10 @@ func (rr *RuleResolution) AddHTTPArchive(moduleName string, modules swift.Module
 	rr.HTTPArchiveRes[moduleName] = modules
 }
 
-func (rr *RuleResolution) AddUnresolved(moduleName string) {
-	rr.UnresModuleNames.Add(moduleName)
+func (rr *RuleResolution) AddUnresolved(moduleNames ...string) {
+	for _, mname := range moduleNames {
+		rr.UnresModuleNames.Add(mname)
+	}
 }
 
 func (rr *RuleResolution) Summary() RuleResolutionSummary {

--- a/gazelle/internal/reslog/rule_resolution.go
+++ b/gazelle/internal/reslog/rule_resolution.go
@@ -73,20 +73,19 @@ func (rr *RuleResolution) Summary() RuleResolutionSummary {
 		Imports:        make([]string, len(rr.Imports)),
 		Builtins:       rr.Builtins.ToSlice(),
 		LocalRes:       make([]ModuleLabel, 0, len(rr.LocalRes)),
-		ExtRes:         nil,
 		HTTPArchiveRes: make([]ModuleLabel, 0, len(rr.HTTPArchiveRes)),
 		Unresolved:     rr.UnresModuleNames.ToSlice(),
 		Deps:           rr.Deps.ToSlice(),
+		ExtRes: newExternalResolutionSummaryFromModuleResolutionResult(
+			rr.ExtResModuleNames,
+			rr.ExtResResult,
+		),
 	}
 	copy(yd.Imports, rr.Imports)
 	for mname, frs := range rr.LocalRes {
 		mt := ModuleLabel{Module: mname, Label: frs[0].Label.String()}
 		yd.LocalRes = append(yd.LocalRes, mt)
 	}
-	yd.ExtRes = newExternalResolutionSummaryFromModuleResolutionResult(
-		rr.ExtResModuleNames,
-		rr.ExtResResult,
-	)
 	for mname, mods := range rr.HTTPArchiveRes {
 		mt := ModuleLabel{Module: mname, Label: mods[0].Label.String()}
 		yd.HTTPArchiveRes = append(yd.HTTPArchiveRes, mt)

--- a/gazelle/internal/reslog/rule_resolution.go
+++ b/gazelle/internal/reslog/rule_resolution.go
@@ -1,0 +1,56 @@
+package reslog
+
+import (
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
+	mapset "github.com/deckarep/golang-set/v2"
+)
+
+type RuleResolution struct {
+	Rule              *rule.Rule
+	Imports           []string
+	Builtins          mapset.Set[string]
+	LocalRes          map[string][]resolve.FindResult
+	ExtResModuleNames []string
+	ExtResResult      *swift.ModuleResolutionResult
+	HTTPArchiveRes    map[string]swift.Modules
+	UnresModuleNames  mapset.Set[string]
+}
+
+func NewRuleResolution(r *rule.Rule, moduleNames []string) *RuleResolution {
+	return &RuleResolution{
+		Rule:             r,
+		Imports:          moduleNames,
+		Builtins:         mapset.NewSet[string](),
+		LocalRes:         make(map[string][]resolve.FindResult),
+		HTTPArchiveRes:   make(map[string]swift.Modules),
+		UnresModuleNames: mapset.NewSet[string](),
+	}
+}
+
+func (rr *RuleResolution) AddBuiltin(moduleName string) {
+	rr.Builtins.Add(moduleName)
+}
+
+func (rr *RuleResolution) AddLocal(moduleName string, frs []resolve.FindResult) {
+	rr.LocalRes[moduleName] = frs
+}
+
+func (rr *RuleResolution) AddExternal(moduleNames []string, mrr *swift.ModuleResolutionResult) {
+	rr.ExtResModuleNames = moduleNames
+	rr.ExtResResult = mrr
+}
+
+func (rr *RuleResolution) AddHTTPArchive(moduleName string, modules swift.Modules) {
+	rr.HTTPArchiveRes[moduleName] = modules
+}
+
+func (rr *RuleResolution) AddUnresolved(moduleName string) {
+	rr.UnresModuleNames.Add(moduleName)
+}
+
+func (rr *RuleResolution) String() string {
+	// TODO(chuck): IMPLEMENT ME!
+	return ""
+}

--- a/gazelle/internal/reslog/rule_resolution_summary.go
+++ b/gazelle/internal/reslog/rule_resolution_summary.go
@@ -8,15 +8,15 @@ import (
 )
 
 type RuleResolutionSummary struct {
-	Name           string                     `yaml:"name"`
-	Kind           string                     `yaml:"kind"`
-	Imports        []string                   `yaml:"imports"`
-	Builtins       []string                   `yaml:"builtins,omitempty"`
-	LocalRes       []ModuleLabel              `yaml:"local_resolution,omitempty"`
-	ExtRes         *ExternalResolutionSummary `yaml:"external_resolution,omitempty"`
-	HTTPArchiveRes []ModuleLabel              `yaml:"http_archive_resolution,omitempty"`
-	Unresolved     []string                   `yaml:"unresolved,omitempty"`
-	Deps           []string                   `yaml:"deps"`
+	Name           string                    `yaml:"name"`
+	Kind           string                    `yaml:"kind"`
+	Imports        []string                  `yaml:"imports"`
+	Builtins       []string                  `yaml:"builtins,omitempty"`
+	LocalRes       []ModuleLabel             `yaml:"local_resolution,omitempty"`
+	ExtRes         ExternalResolutionSummary `yaml:"external_resolution,omitempty"`
+	HTTPArchiveRes []ModuleLabel             `yaml:"http_archive_resolution,omitempty"`
+	Unresolved     []string                  `yaml:"unresolved,omitempty"`
+	Deps           []string                  `yaml:"deps"`
 }
 
 type ModuleLabel struct {
@@ -55,11 +55,11 @@ type ExternalResolutionSummary struct {
 func newExternalResolutionSummaryFromModuleResolutionResult(
 	modules []string,
 	mrr *swift.ModuleResolutionResult,
-) *ExternalResolutionSummary {
+) ExternalResolutionSummary {
 	if mrr == nil {
-		return nil
+		return ExternalResolutionSummary{}
 	}
-	ers := &ExternalResolutionSummary{
+	ers := ExternalResolutionSummary{
 		Modules:    modules,
 		Unresolved: mrr.Unresolved,
 		Products:   make([]Product, len(mrr.Products)),

--- a/gazelle/internal/reslog/rule_resolution_summary.go
+++ b/gazelle/internal/reslog/rule_resolution_summary.go
@@ -13,9 +13,10 @@ type RuleResolutionSummary struct {
 	Imports        []string                   `yaml:"imports"`
 	Builtins       []string                   `yaml:"builtins,omitempty"`
 	LocalRes       []ModuleLabel              `yaml:"local_resolution,omitempty"`
-	ExtRes         *ExternalResolutionSummary `yaml:external_resolution,omitempty`
+	ExtRes         *ExternalResolutionSummary `yaml:"external_resolution,omitempty"`
 	HTTPArchiveRes []ModuleLabel              `yaml:"http_archive_resolution,omitempty"`
 	Unresolved     []string                   `yaml:"unresolved,omitempty"`
+	Deps           []string                   `yaml:"deps"`
 }
 
 type ModuleLabel struct {

--- a/gazelle/internal/reslog/rule_resolution_summary.go
+++ b/gazelle/internal/reslog/rule_resolution_summary.go
@@ -1,0 +1,77 @@
+package reslog
+
+import (
+	"sort"
+
+	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
+	"golang.org/x/exp/slices"
+)
+
+type RuleResolutionSummary struct {
+	Name           string                     `yaml:"name"`
+	Kind           string                     `yaml:"kind"`
+	Imports        []string                   `yaml:"imports"`
+	Builtins       []string                   `yaml:"builtins,omitempty"`
+	LocalRes       []ModuleLabel              `yaml:"local_resolution,omitempty"`
+	ExtRes         *ExternalResolutionSummary `yaml:external_resolution,omitempty`
+	HTTPArchiveRes []ModuleLabel              `yaml:"http_archive_resolution,omitempty"`
+	Unresolved     []string                   `yaml:"unresolved,omitempty"`
+}
+
+type ModuleLabel struct {
+	Module string
+	Label  string
+}
+
+func moduleLabelLess(a, b ModuleLabel) bool {
+	return a.Module < b.Module
+}
+
+type Product struct {
+	Identity string
+	Name     string
+	Labels   []string
+}
+
+func newProductFromSwiftProduct(p *swift.Product) Product {
+	prd := Product{
+		Identity: p.Identity,
+		Name:     p.Name,
+		Labels:   make([]string, len(p.TargetLabels)),
+	}
+	for idx, l := range p.TargetLabels {
+		prd.Labels[idx] = l.String()
+	}
+	return prd
+}
+
+type ExternalResolutionSummary struct {
+	Modules    []string
+	Products   []Product
+	Unresolved []string
+}
+
+func newExternalResolutionSummaryFromModuleResolutionResult(
+	modules []string,
+	mrr *swift.ModuleResolutionResult,
+) *ExternalResolutionSummary {
+	if mrr == nil {
+		return nil
+	}
+	ers := &ExternalResolutionSummary{
+		Modules:    modules,
+		Unresolved: mrr.Unresolved,
+		Products:   make([]Product, len(mrr.Products)),
+	}
+	for idx, p := range mrr.Products {
+		ers.Products[idx] = newProductFromSwiftProduct(p)
+	}
+	sort.Strings(ers.Modules)
+	sort.Strings(ers.Unresolved)
+	slices.SortFunc(ers.Products, func(a, b Product) bool {
+		akey := a.Identity + a.Name
+		bkey := b.Identity + b.Name
+		return akey < bkey
+	})
+	return ers
+}

--- a/gazelle/internal/reslog/rule_resolution_test.go
+++ b/gazelle/internal/reslog/rule_resolution_test.go
@@ -1,0 +1,68 @@
+package reslog_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/reslog"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func newLabel(repo, pkg, name string) *label.Label {
+	l := label.New(repo, pkg, name)
+	return &l
+}
+
+func TestRuleResolution(t *testing.T) {
+	r := rule.NewRule(swift.LibraryRuleKind, "Foo")
+	swiftImports := []string{
+		"UIKit",
+		"LocalA",
+		"LocalB",
+		"ExternalA",
+		"ExternalB",
+		"Custom",
+		"Unresolved",
+	}
+	rr := reslog.NewRuleResolution(r, swiftImports)
+	rr.AddBuiltin("UIKit")
+	rr.AddLocal("LocalA", []resolve.FindResult{
+		{Label: label.New("", "path/to", "LocalA")},
+	})
+	rr.AddLocal("LocalB", []resolve.FindResult{
+		{Label: label.New("", "path/to", "LocalrB")},
+	})
+	rr.AddExternal([]string{"ExternalA", "ExternalB"}, &swift.ModuleResolutionResult{
+		Products: swift.Products{
+			swift.NewProduct(
+				"awesome-repo",
+				"AwesomeProduct",
+				swift.LibraryProductType,
+				[]*label.Label{
+					newLabel("swiftpkg_awesome_repo", "path/to", "ExternalA"),
+					newLabel("swiftpkg_awesome_repo", "path/to", "ExternalB"),
+				},
+			),
+		},
+		Unresolved: []string{"Custom", "Unresolved"},
+	})
+	rr.AddHTTPArchive("Custom", swift.Modules{
+		swift.NewModule(
+			"Custom",
+			"Custom",
+			swiftpkg.SwiftSourceType,
+			newLabel("com_github_example_custom", "", "Custom"),
+			swift.HTTPArchivePkgIdentity,
+			nil,
+		),
+	})
+	rr.AddUnresolved("Unresolved")
+
+	expStr := `
+`
+	assert.Equal(t, expStr, rr.String())
+}

--- a/gazelle/internal/reslog/rule_resolution_test.go
+++ b/gazelle/internal/reslog/rule_resolution_test.go
@@ -87,7 +87,7 @@ func TestRuleResolution(t *testing.T) {
 			{"LocalA", "//path/to:LocalA"},
 			{"LocalB", "//path/to:LocalB"},
 		},
-		ExtRes: &reslog.ExternalResolutionSummary{
+		ExtRes: reslog.ExternalResolutionSummary{
 			Modules: []string{"ExternalA", "ExternalB"},
 			Products: []reslog.Product{
 				{"awesome-repo", "AwesomeProduct", []string{

--- a/gazelle/internal/swiftcfg/BUILD.bazel
+++ b/gazelle/internal/swiftcfg/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/swiftcfg",
     visibility = ["//gazelle:__subpackages__"],
     deps = [
+        "//gazelle/internal/reslog",
         "//gazelle/internal/swift",
         "//gazelle/internal/swiftbin",
         "@bazel_gazelle//config:go_default_library",

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/reslog"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftbin"
 )
@@ -24,12 +25,16 @@ type SwiftConfig struct {
 	// DependencyIndexPath is the full path to the dependency index
 	DependencyIndexPath string
 	UpdatePkgsToLatest  bool
+	ResolutionLogPath   string
+	ResolutionLogFile   *os.File
+	ResolutionLogger    reslog.ResolutionLogger
 }
 
 func NewSwiftConfig() *SwiftConfig {
 	return &SwiftConfig{
 		ModuleFilesCollector: NewModuleFilesCollector(),
 		DependencyIndex:      swift.NewDependencyIndex(),
+		ResolutionLogger:     reslog.NewNoopLogger(),
 	}
 }
 

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/repo"
 	"github.com/bazelbuild/bazel-gazelle/resolve"
 	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/cgrindel/swift_bazel/gazelle/internal/reslog"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftcfg"
 )
@@ -43,6 +44,7 @@ func (l *swiftLang) Resolve(
 	di := sc.DependencyIndex
 	pkgIdentities := di.DirectDepIdentities()
 	swiftImports := imports.([]string)
+	rr := reslog.NewRuleResolution(r, swiftImports)
 
 	// Try to resolve to targets in this project.
 	var deps []string
@@ -53,12 +55,14 @@ func (l *swiftLang) Resolve(
 	externalModules := make([]string, 0, len(swiftImports))
 	for _, imp := range swiftImports {
 		if swift.IsBuiltInModule(imp) {
+			rr.AddBuiltin(imp)
 			continue
 		}
 		findResults := ix.FindRulesByImportWithConfig(
 			c, resolve.ImportSpec{Lang: swiftLangName, Imp: imp}, swiftLangName)
 		if len(findResults) > 0 {
 			addToDeps(findResults[0].Label)
+			rr.AddLocal(imp, findResults)
 		} else {
 			externalModules = append(externalModules, imp)
 		}
@@ -66,6 +70,7 @@ func (l *swiftLang) Resolve(
 
 	// Try to resolve to external Swift pacakage products
 	resResult := di.ResolveModulesToProducts(externalModules, pkgIdentities)
+	rr.AddExternal(externalModules, resResult)
 	for lbl := range resResult.Products.Labels().Iterator().C {
 		addToDeps(*lbl)
 	}
@@ -76,12 +81,14 @@ func (l *swiftLang) Resolve(
 		haModules := di.FindModules(moduleName, []string{swift.HTTPArchivePkgIdentity})
 		if len(haModules) > 0 {
 			addToDeps(*haModules[0].Label)
+			rr.AddHTTPArchive(moduleName, haModules)
 		} else {
 			unresolved = append(unresolved, moduleName)
 		}
 	}
 
 	if len(unresolved) > 0 {
+		rr.AddUnresolved(unresolved...)
 		log.Printf("Unable to find dependency labels for %v",
 			strings.Join(resResult.Unresolved, ", "))
 	}
@@ -90,6 +97,11 @@ func (l *swiftLang) Resolve(
 	if len(deps) > 0 {
 		r.SetAttr("deps", deps)
 	}
+
+	// Log the info. We do not have a callback to let us know when Gazelle is about the finish. So,
+	// we will flush it immediately.
+	sc.ResolutionLogger.Log(rr)
+	sc.ResolutionLogger.Flush()
 }
 
 // Adjusts the label to not include the repo value if they are in the same repo.

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -44,7 +44,7 @@ func (l *swiftLang) Resolve(
 	di := sc.DependencyIndex
 	pkgIdentities := di.DirectDepIdentities()
 	swiftImports := imports.([]string)
-	rr := reslog.NewRuleResolution(r, swiftImports)
+	rr := reslog.NewRuleResolution(from, r, swiftImports)
 
 	// Try to resolve to targets in this project.
 	var deps []string
@@ -94,6 +94,7 @@ func (l *swiftLang) Resolve(
 	}
 
 	sort.Strings(deps)
+	rr.AddDep(deps...)
 	if len(deps) > 0 {
 		r.SetAttr("deps", deps)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/exp v0.0.0-20230131160201-f062dba9d201
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -205,6 +205,14 @@ def swift_bazel_go_dependencies():
         version = "v0.0.0-20161208181325-20d25e280405",
     )
     go_repository(
+        name = "in_gopkg_yaml_v2",
+        build_external = "external",
+        importpath = "gopkg.in/yaml.v2",
+        sum = "h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=",
+        version = "v2.4.0",
+    )
+
+    go_repository(
         name = "in_gopkg_yaml_v3",
         build_external = "external",
         importpath = "gopkg.in/yaml.v3",


### PR DESCRIPTION
If enabled, it creates a YAML file with records describing the resolution process for each evaluated rule.

Execute by passing the `--resolution_log` flag:
```sh
$ bazel run //:update_build_files -- "--resolution_log=${PWD}/res_log.yml"
```
Don't forget to specify `${PWD}` or an absolute path. Otherwise, the log file will be written to the runfiles directory.

Related to #202.