### PR TITLE
fix: change `byName` resolution logic

### DIFF
--- a/swiftpkg/internal/deps_indexes.bzl
+++ b/swiftpkg/internal/deps_indexes.bzl
@@ -31,6 +31,7 @@ def _new(modules = [], products = []):
     modules_by_name = {}
     modules_by_label = {}
     products_by_key = {}
+    products_by_name = {}
 
     # buildifier: disable=uninitialized
     def _add_module(m):
@@ -47,6 +48,9 @@ def _new(modules = [], products = []):
     def _add_product(p):
         key = _new_product_index_key(p.identity, p.name)
         products_by_key[key] = p
+        prds = products_by_name.get(p.name, [])
+        prds.append(p)
+        products_by_name[p.name] = prds
 
     for module in modules:
         _add_module(module)
@@ -57,6 +61,7 @@ def _new(modules = [], products = []):
         modules_by_name = modules_by_name,
         modules_by_label = modules_by_label,
         products_by_key = products_by_key,
+        products_by_name = products_by_name,
     )
 
 def _new_module_from_dict(mod_dict):

--- a/swiftpkg/internal/deps_indexes.bzl
+++ b/swiftpkg/internal/deps_indexes.bzl
@@ -234,24 +234,6 @@ def _find_product(deps_index, identity, name):
     key = _new_product_index_key(identity, name)
     return deps_index.products.get(key)
 
-def _resolve_product_labels(deps_index, identity, name):
-    """Returns the Bazel labels that represent the specified product.
-
-    Args:
-        deps_index: A `dict` as returned by `deps_indexes.new_from_json`.
-        identity: The dependency identity as a `string`.
-        name: The product name as a `string`.
-
-    Returns:
-        A `list` of Bazel label `struct` values as returned by
-        `bazel_labels.new`. If the product is not found, an empty `list` is
-        returned.
-    """
-    product = _find_product(deps_index, identity, name)
-    if product == None:
-        return []
-    return product.target_labels
-
 def _new_ctx(deps_index, preferred_repo_name = None, restrict_to_repo_names = []):
     """Create a new context struct that encapsulates a dependency index along with \
     select lookup criteria.
@@ -320,5 +302,4 @@ deps_indexes = struct(
     new_product = _new_product,
     resolve_module = _resolve_module,
     resolve_module_with_ctx = _resolve_module_with_ctx,
-    resolve_product_labels = _resolve_product_labels,
 )

--- a/swiftpkg/internal/deps_indexes.bzl
+++ b/swiftpkg/internal/deps_indexes.bzl
@@ -30,7 +30,7 @@ def _new_from_json(json_str):
 def _new(modules = [], products = []):
     modules_by_name = {}
     modules_by_label = {}
-    pi = {}
+    products_by_key = {}
 
     # buildifier: disable=uninitialized
     def _add_module(m):
@@ -46,7 +46,7 @@ def _new(modules = [], products = []):
     # buildifier: disable=uninitialized
     def _add_product(p):
         key = _new_product_index_key(p.identity, p.name)
-        pi[key] = p
+        products_by_key[key] = p
 
     for module in modules:
         _add_module(module)
@@ -56,7 +56,7 @@ def _new(modules = [], products = []):
     return struct(
         modules_by_name = modules_by_name,
         modules_by_label = modules_by_label,
-        products = pi,
+        products_by_key = products_by_key,
     )
 
 def _new_module_from_dict(mod_dict):
@@ -216,6 +216,29 @@ def _resolve_module(
         return None
     return modules[0]
 
+def _resolve_product(
+        deps_index,
+        product_name,
+        preferred_repo_name = None,
+        restrict_to_repo_names = []):
+    """Finds a Bazel label that provides the specified product.
+
+    Args:
+        deps_index: A `dict` as returned by `deps_indexes.new_from_json`.
+        product_name: The name of the product as a `string`
+        preferred_repo_name: Optional. If a target in this repository provides
+            the product, prefer it.
+        restrict_to_repo_names: Optional. A `list` of repository names to
+            restrict the match.
+
+    Returns:
+        If a product is found, a `struct` as returned by `bazel_labels.new`.
+        Otherwise, `None`.
+    """
+
+    # TODO(chuck): IMPLEMENT ME!
+    return None
+
 def _new_product_index_key(identity, name):
     return identity.lower() + "|" + name
 
@@ -232,7 +255,7 @@ def _get_product(deps_index, identity, name):
         found, returns `None`.
     """
     key = _new_product_index_key(identity, name)
-    return deps_index.products.get(key)
+    return deps_index.products_by_key.get(key)
 
 def _new_ctx(deps_index, preferred_repo_name = None, restrict_to_repo_names = []):
     """Create a new context struct that encapsulates a dependency index along with \
@@ -275,6 +298,26 @@ def _resolve_module_with_ctx(
         restrict_to_repo_names = deps_index_ctx.restrict_to_repo_names,
     )
 
+def _resolve_product_with_ctx(
+        deps_index_ctx,
+        product_name):
+    """Finds a Bazel label that provides the specified product.
+
+    Args:
+        deps_index_ctx: A `struct` as returned by `deps_indexes.new_ctx`.
+        product_name: The name of the product as a `string`
+
+    Returns:
+        If a product is found, a `struct` as returned by `bazel_labels.new`.
+        Otherwise, `None`.
+    """
+    return _resolve_product(
+        deps_index = deps_index_ctx.deps_index,
+        product_name = product_name,
+        preferred_repo_name = deps_index_ctx.preferred_repo_name,
+        restrict_to_repo_names = deps_index_ctx.restrict_to_repo_names,
+    )
+
 src_types = struct(
     unknown = "unknown",
     swift = "swift",
@@ -302,4 +345,6 @@ deps_indexes = struct(
     new_product = _new_product,
     resolve_module = _resolve_module,
     resolve_module_with_ctx = _resolve_module_with_ctx,
+    resolve_product = _resolve_product,
+    resolve_product_with_ctx = _resolve_product_with_ctx,
 )

--- a/swiftpkg/internal/deps_indexes.bzl
+++ b/swiftpkg/internal/deps_indexes.bzl
@@ -219,7 +219,7 @@ def _resolve_module(
 def _new_product_index_key(identity, name):
     return identity.lower() + "|" + name
 
-def _find_product(deps_index, identity, name):
+def _get_product(deps_index, identity, name):
     """Retrieves the product based upon the identity and the name.
 
     Args:
@@ -291,7 +291,7 @@ src_types = struct(
 )
 
 deps_indexes = struct(
-    find_product = _find_product,
+    get_product = _get_product,
     get_module = _get_module,
     labels_for_module = _labels_for_module,
     modules_for_product = _modules_for_product,

--- a/swiftpkg/internal/deps_indexes.bzl
+++ b/swiftpkg/internal/deps_indexes.bzl
@@ -186,7 +186,7 @@ def _resolve_module(
             restrict the match.
 
     Returns:
-        If a module is found, a `struct` as returned by `bazel_labels.new`.
+        If a module is found, a `struct` as returned by `deps_indexes.new_module`.
         Otherwise, `None`.
     """
     modules = deps_index.modules_by_name.get(module_name, [])
@@ -237,15 +237,53 @@ def _resolve_product(
             restrict the match.
 
     Returns:
-        If a product is found, a `struct` as returned by `bazel_labels.new`.
+        If a product is found, a `struct` as returned by `deps_indexes.new_product`.
         Otherwise, `None`.
     """
+    products = deps_index.products_by_name.get(product_name, [])
+    if len(products) == 0:
+        return None
 
-    # TODO(chuck): IMPLEMENT ME!
-    return None
+    # If a repo name is provided, prefer that over any other matches
+    if preferred_repo_name != None:
+        preferred_repo_name = bazel_repo_names.normalize(preferred_repo_name)
+        product = lists.find(
+            products,
+            lambda p: lists.contains(
+                p.target_labels,
+                lambda tl: tl.repository_name == preferred_repo_name,
+            ),
+        )
+        if product != None:
+            return product
+
+    # If we are meant to only find a match in a set of repo names, then
+    if len(restrict_to_repo_names) > 0:
+        restrict_to_repo_names = [
+            bazel_repo_names.normalize(rn)
+            for rn in restrict_to_repo_names
+        ]
+        repo_names = sets.make(restrict_to_repo_names)
+        products = [
+            p
+            for p in products
+            if lists.contains(
+                p.target_labels,
+                lambda tl: sets.contains(repo_names, tl.repository_name),
+            )
+        ]
+
+    if len(products) == 0:
+        return None
+    return products[0]
 
 def _new_product_index_key(identity, name):
     return identity.lower() + "|" + name
+
+def _new_product_index_key_for_product(product):
+    if product == None:
+        return None
+    return _new_product_index_key(product.identity, product.name)
 
 def _get_product(deps_index, identity, name):
     """Retrieves the product based upon the identity and the name.
@@ -348,6 +386,8 @@ deps_indexes = struct(
     new_from_json = _new_from_json,
     new_module = _new_module,
     new_product = _new_product,
+    new_product_index_key = _new_product_index_key,
+    new_product_index_key_for_product = _new_product_index_key_for_product,
     resolve_module = _resolve_module,
     resolve_module_with_ctx = _resolve_module_with_ctx,
     resolve_product = _resolve_product,

--- a/swiftpkg/internal/pkginfo_target_deps.bzl
+++ b/swiftpkg/internal/pkginfo_target_deps.bzl
@@ -27,20 +27,27 @@ def make_pkginfo_target_deps(bazel_labels):
             representing the labels for the target dependency.
         """
         if target_dep.by_name:
-            # GH194: A byName reference can be a product or a module.
-            # This should look for a matching product first. Then, look for a
-            # module directly?
             condition = target_dep.by_name.condition
-            module = deps_indexes.resolve_module_with_ctx(
+            product = deps_indexes.resolve_product_with_ctx(
                 pkg_ctx.deps_index_ctx,
                 target_dep.by_name.name,
             )
+            if product != None:
+                modules = deps_indexes.modules_for_product(
+                    deps_index = pkg_ctx.deps_index_ctx.deps_index,
+                    product = product,
+                )
+            else:
+                module = deps_indexes.resolve_module_with_ctx(
+                    pkg_ctx.deps_index_ctx,
+                    target_dep.by_name.name,
+                )
 
-            # Seeing Package.swift files with byName dependencies that
-            # cannot be resolved (i.e., they do not exist).
-            # Example `protoc-gen-swift` in
-            # `https://github.com/grpc/grpc-swift.git`.
-            modules = [module] if module != None else []
+                # Seeing Package.swift files with byName dependencies that
+                # cannot be resolved (i.e., they do not exist).
+                # Example `protoc-gen-swift` in
+                # `https://github.com/grpc/grpc-swift.git`.
+                modules = [module] if module != None else []
 
         elif target_dep.target:
             condition = target_dep.target.condition

--- a/swiftpkg/internal/pkginfo_target_deps.bzl
+++ b/swiftpkg/internal/pkginfo_target_deps.bzl
@@ -66,7 +66,7 @@ Unable to resolve target reference target dependency for {module_name}.\
 Did not find external dependency with name/identity {}.\
 """.format(prod_ref.dep_name))
 
-            product = deps_indexes.find_product(
+            product = deps_indexes.get_product(
                 deps_index = pkg_ctx.deps_index_ctx.deps_index,
                 identity = dep.identity,
                 name = prod_ref.product_name,

--- a/swiftpkg/internal/pkginfo_target_deps.bzl
+++ b/swiftpkg/internal/pkginfo_target_deps.bzl
@@ -26,28 +26,44 @@ def make_pkginfo_target_deps(bazel_labels):
             A `list` of `struct` values as returned by `bzl_selects.new`
             representing the labels for the target dependency.
         """
+
+        # Find the depender module
+        depender_module = deps_indexes.resolve_module_with_ctx(
+            pkg_ctx.deps_index_ctx,
+            depender_module_name,
+        )
+        if depender_module == None:
+            fail("Unable to find depender module named {}.".format(depender_module_name))
+
         if target_dep.by_name:
             condition = target_dep.by_name.condition
-            product = deps_indexes.resolve_product_with_ctx(
+
+            # If we found a module in the depender's repo, then use it.
+            # Else if we found a product, use it.
+            # Else use whatever we found from the modules resolution.
+            module = deps_indexes.resolve_module_with_ctx(
                 pkg_ctx.deps_index_ctx,
                 target_dep.by_name.name,
             )
-            if product != None:
-                modules = deps_indexes.modules_for_product(
-                    deps_index = pkg_ctx.deps_index_ctx.deps_index,
-                    product = product,
-                )
+            if module != None and \
+               module.label.repository_name == depender_module.label.repository_name:
+                modules = [module]
             else:
-                module = deps_indexes.resolve_module_with_ctx(
+                product = deps_indexes.resolve_product_with_ctx(
                     pkg_ctx.deps_index_ctx,
                     target_dep.by_name.name,
                 )
-
-                # Seeing Package.swift files with byName dependencies that
-                # cannot be resolved (i.e., they do not exist).
-                # Example `protoc-gen-swift` in
-                # `https://github.com/grpc/grpc-swift.git`.
-                modules = [module] if module != None else []
+                if product != None:
+                    modules = deps_indexes.modules_for_product(
+                        deps_index = pkg_ctx.deps_index_ctx.deps_index,
+                        product = product,
+                    )
+                else:
+                    # Seeing Package.swift files with byName dependencies that
+                    # cannot be resolved (i.e., they do not exist).
+                    # Example `protoc-gen-swift` in
+                    # `https://github.com/grpc/grpc-swift.git`.
+                    modules = [module] if module != None else []
 
         elif target_dep.target:
             condition = target_dep.target.condition
@@ -94,14 +110,6 @@ Unable to resolve product reference target dependency for product {prod_name} pr
             fail("""\
 Unrecognized target dependency while generating a Bazel dependency label.\
 """)
-
-        # Find the depender module
-        depender_module = deps_indexes.resolve_module_with_ctx(
-            pkg_ctx.deps_index_ctx,
-            depender_module_name,
-        )
-        if depender_module == None:
-            fail("Unable to find depender module named {}.".format(depender_module_name))
 
         labels = lists.flatten([
             deps_indexes.labels_for_module(module, depender_module.src_type)

--- a/swiftpkg/tests/deps_indexes_tests.bzl
+++ b/swiftpkg/tests/deps_indexes_tests.bzl
@@ -7,9 +7,11 @@ load("//swiftpkg/internal:deps_indexes.bzl", "deps_indexes")
 def _new_from_json_test(ctx):
     env = unittest.begin(ctx)
 
-    asserts.equals(env, 4, len(_deps_index.modules_by_name))
-    asserts.equals(env, 6, len(_deps_index.modules_by_label))
-    asserts.equals(env, 0, len(_deps_index.products_by_key))
+    asserts.equals(env, 4, len(_deps_index.modules_by_name), "modules_by_name len")
+    asserts.equals(env, 6, len(_deps_index.modules_by_label), "modules_by_label len")
+    asserts.equals(env, 2, len(_deps_index.products_by_key), "products_by_key len")
+    asserts.equals(env, 1, len(_deps_index.products_by_name), "products_by_name len")
+    asserts.equals(env, 2, len(_deps_index.products_by_name["Foo"]), "number of Foo products")
 
     return unittest.end(env)
 
@@ -218,7 +220,10 @@ _deps_index_json = """
     {"name": "Bar", "c99name": "Bar", "src_type": "swift", "label": "@example_another_repo//Sources/Bar"},
     {"name": "ObjcLibrary", "c99name": "ObjcLibrary", "src_type": "objc", "label": "@example_cool_repo//:ObjcLibrary"}
   ],
-  "products": []
+  "products": [
+    {"identity": "example_cool_repo", "name": "Foo", "type": "library", "target_labels": ["@example_cool_repo//:Foo", "@example_cool_repo//:Bar"]},
+    {"identity": "example_another_repo", "name": "Foo", "type": "library", "target_labels": ["@example_another_repo//Sources/Foo"]}
+  ]
 }
 """
 

--- a/swiftpkg/tests/deps_indexes_tests.bzl
+++ b/swiftpkg/tests/deps_indexes_tests.bzl
@@ -9,8 +9,9 @@ def _new_from_json_test(ctx):
 
     asserts.equals(env, 4, len(_deps_index.modules_by_name), "modules_by_name len")
     asserts.equals(env, 6, len(_deps_index.modules_by_label), "modules_by_label len")
-    asserts.equals(env, 2, len(_deps_index.products_by_key), "products_by_key len")
-    asserts.equals(env, 1, len(_deps_index.products_by_name), "products_by_name len")
+    asserts.equals(env, 3, len(_deps_index.products_by_key), "products_by_key len")
+    asserts.equals(env, 2, len(_deps_index.products_by_name), "products_by_name len")
+    asserts.equals(env, 1, len(_deps_index.products_by_name["ArgumentParser"]), "number of ArgumentParser products")
     asserts.equals(env, 2, len(_deps_index.products_by_name["Foo"]), "number of Foo products")
 
     return unittest.end(env)
@@ -200,6 +201,109 @@ def _labels_for_module_test(ctx):
 
 labels_for_module_test = unittest.make(_labels_for_module_test)
 
+def _resolve_product_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(
+            msg = "ArgumentParser product",
+            product = "ArgumentParser",
+            preferred = None,
+            restrict_to = [],
+            exp = deps_indexes.new_product_index_key(
+                "apple_swift_argument_parser",
+                "ArgumentParser",
+            ),
+        ),
+        struct(
+            msg = "product not in index",
+            product = "DoesNotExist",
+            preferred = None,
+            restrict_to = [],
+            exp = None,
+        ),
+        struct(
+            msg = "preferred repo name exists",
+            product = "Foo",
+            preferred = "example_cool_repo",
+            restrict_to = [],
+            exp = deps_indexes.new_product_index_key(
+                "example_cool_repo",
+                "Foo",
+            ),
+        ),
+        struct(
+            msg = "preferred repo name not found",
+            product = "ArgumentParser",
+            preferred = "example_another_repo",
+            restrict_to = [],
+            exp = deps_indexes.new_product_index_key(
+                "apple_swift_argument_parser",
+                "ArgumentParser",
+            ),
+        ),
+        struct(
+            msg = "restrict to repos, found one",
+            product = "Foo",
+            preferred = None,
+            restrict_to = ["some_other_repo", "example_another_repo"],
+            exp = deps_indexes.new_product_index_key(
+                "example_another_repo",
+                "Foo",
+            ),
+        ),
+        struct(
+            msg = "restrict to repos, not found",
+            product = "Foo",
+            preferred = None,
+            restrict_to = ["some_other_repo"],
+            exp = None,
+        ),
+        struct(
+            msg = "preferred repo and restrict to repos, found preferred",
+            product = "Foo",
+            preferred = "example_cool_repo",
+            restrict_to = ["example_cool_repo", "example_another_repo"],
+            exp = deps_indexes.new_product_index_key(
+                "example_cool_repo",
+                "Foo",
+            ),
+        ),
+    ]
+    for t in tests:
+        actual = deps_indexes.resolve_product(
+            _deps_index,
+            product_name = t.product,
+            preferred_repo_name = t.preferred,
+            restrict_to_repo_names = t.restrict_to,
+        )
+        actual_key = deps_indexes.new_product_index_key_for_product(actual)
+        asserts.equals(env, t.exp, actual_key, t.msg)
+
+    return unittest.end(env)
+
+resolve_product_test = unittest.make(_resolve_product_test)
+
+def _resolve_product_with_ctx_test(ctx):
+    env = unittest.begin(ctx)
+
+    deps_index_ctx = deps_indexes.new_ctx(
+        deps_index = _deps_index,
+        preferred_repo_name = "example_cool_repo",
+        restrict_to_repo_names = ["example_cool_repo", "example_another_repo"],
+    )
+    actual = deps_indexes.resolve_product_with_ctx(
+        deps_index_ctx = deps_index_ctx,
+        product_name = "Foo",
+    )
+    exp_key = deps_indexes.new_product_index_key("example_cool_repo", "Foo")
+    actual_key = deps_indexes.new_product_index_key_for_product(actual)
+    asserts.equals(env, exp_key, actual_key)
+
+    return unittest.end(env)
+
+resolve_product_with_ctx_test = unittest.make(_resolve_product_with_ctx_test)
+
 def deps_indexes_test_suite():
     return unittest.suite(
         "deps_indexes_tests",
@@ -207,6 +311,8 @@ def deps_indexes_test_suite():
         get_module_test,
         resolve_module_test,
         resolve_module_with_ctx_test,
+        resolve_product_test,
+        resolve_product_with_ctx_test,
         labels_for_module_test,
     )
 
@@ -221,6 +327,7 @@ _deps_index_json = """
     {"name": "ObjcLibrary", "c99name": "ObjcLibrary", "src_type": "objc", "label": "@example_cool_repo//:ObjcLibrary"}
   ],
   "products": [
+    {"identity": "apple_swift_argument_parser", "name": "ArgumentParser", "type": "library", "target_labels": ["@apple_swift_argument_parser//Sources/ArgumentParser"]},
     {"identity": "example_cool_repo", "name": "Foo", "type": "library", "target_labels": ["@example_cool_repo//:Foo", "@example_cool_repo//:Bar"]},
     {"identity": "example_another_repo", "name": "Foo", "type": "library", "target_labels": ["@example_another_repo//Sources/Foo"]}
   ]

--- a/swiftpkg/tests/deps_indexes_tests.bzl
+++ b/swiftpkg/tests/deps_indexes_tests.bzl
@@ -9,7 +9,7 @@ def _new_from_json_test(ctx):
 
     asserts.equals(env, 4, len(_deps_index.modules_by_name))
     asserts.equals(env, 6, len(_deps_index.modules_by_label))
-    asserts.equals(env, 0, len(_deps_index.products))
+    asserts.equals(env, 0, len(_deps_index.products_by_key))
 
     return unittest.end(env)
 

--- a/swiftpkg/tests/pkginfo_target_deps_tests.bzl
+++ b/swiftpkg/tests/pkginfo_target_deps_tests.bzl
@@ -29,7 +29,8 @@ _external_dep = pkginfos.new_dependency(
         ],
     ),
 )
-_by_name = pkginfos.new_by_name_reference("Foo")
+_target_by_name = pkginfos.new_by_name_reference("Foo")
+_product_by_name = pkginfos.new_by_name_reference("AwesomeProduct")
 _product_ref = pkginfos.new_product_reference(
     product_name = "AwesomeProduct",
     dep_name = _external_dep.name,
@@ -92,6 +93,12 @@ _deps_index_json = """\
       "c99name": "Foo",
       "src_type": "swift",
       "label": "@swiftpkg_example_swift_package//:Source/Foo"
+    },
+    {
+      "name": "Baz",
+      "c99name": "Baz",
+      "src_type": "swift",
+      "label": "@swiftpkg_example_swift_package//:Source/Baz"
     }
   ],
   "products": [
@@ -100,7 +107,8 @@ _deps_index_json = """\
       "name": "AwesomeProduct",
       "type": "library",
       "target_labels": [
-        "@swiftpkg_example_swift_package//:AwesomePackage"
+        "@swiftpkg_example_swift_package//:AwesomePackage",
+        "@swiftpkg_example_swift_package//:Source/Baz"
       ]
     }
   ]
@@ -118,14 +126,31 @@ def _bzl_select_list_test(ctx):
 
     tests = [
         struct(
-            msg = "by name, no condition",
-            td = pkginfos.new_target_dependency(by_name = _by_name),
+            msg = "by name for target, no condition",
+            td = pkginfos.new_target_dependency(by_name = _target_by_name),
             exp = [
                 bzl_selects.new(
                     kind = pkginfo_target_deps.target_dep_kind,
                     value = [
                         bazel_labels.normalize(
                             "@swiftpkg_example_swift_package//:Source/Foo",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        struct(
+            msg = "by name for product, no condition",
+            td = pkginfos.new_target_dependency(by_name = _product_by_name),
+            exp = [
+                bzl_selects.new(
+                    kind = pkginfo_target_deps.target_dep_kind,
+                    value = [
+                        bazel_labels.normalize(
+                            "@swiftpkg_example_swift_package//:AwesomePackage",
+                        ),
+                        bazel_labels.normalize(
+                            "@swiftpkg_example_swift_package//:Source/Baz",
                         ),
                     ],
                 ),
@@ -140,6 +165,9 @@ def _bzl_select_list_test(ctx):
                     value = [
                         bazel_labels.normalize(
                             "@swiftpkg_example_swift_package//:AwesomePackage",
+                        ),
+                        bazel_labels.normalize(
+                            "@swiftpkg_example_swift_package//:Source/Baz",
                         ),
                     ],
                 ),
@@ -184,6 +212,9 @@ def _bzl_select_list_test(ctx):
                     value = [
                         bazel_labels.normalize(
                             "@swiftpkg_example_swift_package//:AwesomePackage",
+                        ),
+                        bazel_labels.normalize(
+                            "@swiftpkg_example_swift_package//:Source/Baz",
                         ),
                     ],
                     condition = c,

--- a/swiftpkg/tests/pkginfo_target_deps_tests.bzl
+++ b/swiftpkg/tests/pkginfo_target_deps_tests.bzl
@@ -29,7 +29,9 @@ _external_dep = pkginfos.new_dependency(
         ],
     ),
 )
-_target_by_name = pkginfos.new_by_name_reference("Foo")
+
+# _target_by_name = pkginfos.new_by_name_reference("Foo")
+_target_by_name = pkginfos.new_by_name_reference("Baz")
 _product_by_name = pkginfos.new_by_name_reference("AwesomeProduct")
 _product_ref = pkginfos.new_product_reference(
     product_name = "AwesomeProduct",
@@ -99,6 +101,12 @@ _deps_index_json = """\
       "c99name": "Baz",
       "src_type": "swift",
       "label": "@swiftpkg_example_swift_package//:Source/Baz"
+    },
+    {
+      "name": "MoreBaz",
+      "c99name": "MoreBaz",
+      "src_type": "swift",
+      "label": "@swiftpkg_example_swift_package//:Source/MoreBaz"
     }
   ],
   "products": [
@@ -109,6 +117,15 @@ _deps_index_json = """\
       "target_labels": [
         "@swiftpkg_example_swift_package//:AwesomePackage",
         "@swiftpkg_example_swift_package//:Source/Baz"
+      ]
+    },
+    {
+      "identity": "example-swift-package",
+      "name": "Baz",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_example_swift_package//:Source/Baz",
+        "@swiftpkg_example_swift_package//:Source/MoreBaz"
       ]
     }
   ]
@@ -126,14 +143,14 @@ def _bzl_select_list_test(ctx):
 
     tests = [
         struct(
-            msg = "by name for target, no condition",
+            msg = "by name for target not the product with the same name, no condition",
             td = pkginfos.new_target_dependency(by_name = _target_by_name),
             exp = [
                 bzl_selects.new(
                     kind = pkginfo_target_deps.target_dep_kind,
                     value = [
                         bazel_labels.normalize(
-                            "@swiftpkg_example_swift_package//:Source/Foo",
+                            "@swiftpkg_example_swift_package//:Source/Baz",
                         ),
                     ],
                 ),


### PR DESCRIPTION
- Add support for product resolution in `deps_indexes`.
- Update `pkginfo_target_deps` to resolve byName references in the following priority:
  1. Module in the same repo.
  2. Product with the specified name.
  3. Any module with the specified name.

Closes #199.