### PR TITLE
feat: provide options for printing and updating bzlmod stanzas in `MODULE.bazel`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,6 +166,7 @@ filegroup(
         "//gazelle/internal/swiftbin:all_files",
         "//gazelle/internal/swiftcfg:all_files",
         "//gazelle/internal/swiftpkg:all_files",
+        "//gazelle/internal/updmarker:all_files",
         "//swiftpkg:all_files",
         "//swiftpkg/internal:all_files",
         "//swiftpkg/internal/modulemap_parser:all_files",

--- a/docs/rules_and_macros_overview.md
+++ b/docs/rules_and_macros_overview.md
@@ -33,8 +33,8 @@ Defines gazelle update-repos targets that are used to resolve and update     Swi
 | <a id="swift_update_packages-swift_deps_fn"></a>swift_deps_fn |  Optional. The name of the Starlark function in the <code>swift_deps</code> file that should be updated with the Swift package dependencies as a <code>string</code>.   |  <code>"swift_dependencies"</code> |
 | <a id="swift_update_packages-swift_deps_index"></a>swift_deps_index |  Optional. The relative path to the Swift dependencies index JSON file. This path is relative to the repository root, not the location of this declaration.   |  <code>"swift_deps_index.json"</code> |
 | <a id="swift_update_packages-print_bzlmod_stanzas"></a>print_bzlmod_stanzas |  Optional. Determines whether the Gazelle extension prints out bzlmod Starlark code that can be pasted into your <code>MODULE.bazel</code>.   |  <code>False</code> |
-| <a id="swift_update_packages-update_bzlmod_stanzas"></a>update_bzlmod_stanzas |  <p align="center"> - </p>   |  <code>False</code> |
-| <a id="swift_update_packages-bazel_module"></a>bazel_module |  <p align="center"> - </p>   |  <code>"MODULE.bazel"</code> |
+| <a id="swift_update_packages-update_bzlmod_stanzas"></a>update_bzlmod_stanzas |  Optional. Determines whether the Gazelle extension adds/updates the bzlmod Starlark code to MODULE.bazel.   |  <code>False</code> |
+| <a id="swift_update_packages-bazel_module"></a>bazel_module |  Optional. The relative path to the <code>MODULE.bazel</code> file.   |  <code>"MODULE.bazel"</code> |
 | <a id="swift_update_packages-kwargs"></a>kwargs |  Attributes that are passed along to the gazelle declarations.   |  none |
 
 

--- a/docs/rules_and_macros_overview.md
+++ b/docs/rules_and_macros_overview.md
@@ -16,7 +16,7 @@ On this page:
 
 <pre>
 swift_update_packages(<a href="#swift_update_packages-name">name</a>, <a href="#swift_update_packages-gazelle">gazelle</a>, <a href="#swift_update_packages-package_manifest">package_manifest</a>, <a href="#swift_update_packages-swift_deps">swift_deps</a>, <a href="#swift_update_packages-swift_deps_fn">swift_deps_fn</a>, <a href="#swift_update_packages-swift_deps_index">swift_deps_index</a>,
-                      <a href="#swift_update_packages-kwargs">kwargs</a>)
+                      <a href="#swift_update_packages-print_bzlmod_stanzas">print_bzlmod_stanzas</a>, <a href="#swift_update_packages-update_bzlmod_stanzas">update_bzlmod_stanzas</a>, <a href="#swift_update_packages-bazel_module">bazel_module</a>, <a href="#swift_update_packages-kwargs">kwargs</a>)
 </pre>
 
 Defines gazelle update-repos targets that are used to resolve and update     Swift package dependencies.
@@ -32,6 +32,9 @@ Defines gazelle update-repos targets that are used to resolve and update     Swi
 | <a id="swift_update_packages-swift_deps"></a>swift_deps |  Optional. The name of the Starlark file that should be updated with the Swift package dependencies as a <code>string</code>.   |  <code>"swift_deps.bzl"</code> |
 | <a id="swift_update_packages-swift_deps_fn"></a>swift_deps_fn |  Optional. The name of the Starlark function in the <code>swift_deps</code> file that should be updated with the Swift package dependencies as a <code>string</code>.   |  <code>"swift_dependencies"</code> |
 | <a id="swift_update_packages-swift_deps_index"></a>swift_deps_index |  Optional. The relative path to the Swift dependencies index JSON file. This path is relative to the repository root, not the location of this declaration.   |  <code>"swift_deps_index.json"</code> |
+| <a id="swift_update_packages-print_bzlmod_stanzas"></a>print_bzlmod_stanzas |  Optional. Determines whether the Gazelle extension prints out bzlmod Starlark code that can be pasted into your <code>MODULE.bazel</code>.   |  <code>False</code> |
+| <a id="swift_update_packages-update_bzlmod_stanzas"></a>update_bzlmod_stanzas |  <p align="center"> - </p>   |  <code>False</code> |
+| <a id="swift_update_packages-bazel_module"></a>bazel_module |  <p align="center"> - </p>   |  <code>"MODULE.bazel"</code> |
 | <a id="swift_update_packages-kwargs"></a>kwargs |  Attributes that are passed along to the gazelle declarations.   |  none |
 
 

--- a/examples/pkg_manifest_minimal/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/BUILD.bazel
@@ -32,6 +32,7 @@ gazelle(
 swift_update_packages(
     name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
+    print_bzlmod_stanzas = True,
 )
 
 bzl_library(

--- a/examples/pkg_manifest_minimal/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/BUILD.bazel
@@ -33,6 +33,7 @@ swift_update_packages(
     name = "swift_update_pkgs",
     gazelle = ":gazelle_bin",
     print_bzlmod_stanzas = True,
+    update_bzlmod_stanzas = True,
 )
 
 bzl_library(

--- a/examples/pkg_manifest_minimal/MODULE.bazel
+++ b/examples/pkg_manifest_minimal/MODULE.bazel
@@ -27,6 +27,7 @@ bazel_dep(
     repo_name = "bazel_gazelle",
 )
 
+# swift_deps START
 swift_deps = use_extension(
     "@cgrindel_swift_bazel//:extensions.bzl",
     "swift_deps",
@@ -41,6 +42,4 @@ use_repo(
     "swiftpkg_swift_log",
     "swiftpkg_swiftformat",
 )
-
-# IDEA
-# use_repo(swift_deps, "swift_deps")
+# swift_deps END

--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//gazelle/internal/swiftbin",
         "//gazelle/internal/swiftcfg",
         "//gazelle/internal/swiftpkg",
+        "//gazelle/internal/updmarker",
         "@bazel_gazelle//config:go_default_library",
         "@bazel_gazelle//label:go_default_library",
         "@bazel_gazelle//language:go_default_library",

--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -37,12 +37,22 @@ func (*swiftLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) 
 			&sc.UpdatePkgsToLatest,
 			"swift_update_packages_to_latest",
 			false,
-			"Determines whether to update the Swift packages to their latest eligible version.")
+			"determines whether to update the Swift packages to their latest eligible version.")
 		fs.BoolVar(
 			&sc.PrintBzlmodStanzas,
 			"print_bzlmod_stanzas",
 			false,
-			"Determines whether to print the bzlmod stanzas to add to a MODULE.bazel file.")
+			"determines whether to print the bzlmod stanzas to add to a MODULE.bazel file.")
+		fs.BoolVar(
+			&sc.UpdateBzlmodStanzas,
+			"update_bzlmod_stanzas",
+			false,
+			"determines whether to update your MODULE.bazel file with the appropriate stanzas.")
+		fs.StringVar(
+			&sc.BazelModulePath,
+			"bazel_module",
+			"MODULE.bazel",
+			"the location of the MODULE.bazel file")
 	}
 
 	// Store the config for later steps

--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -49,7 +49,7 @@ func (*swiftLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) 
 			false,
 			"determines whether to update your MODULE.bazel file with the appropriate stanzas.")
 		fs.StringVar(
-			&sc.BazelModulePath,
+			&sc.BazelModuleRel,
 			"bazel_module",
 			"MODULE.bazel",
 			"the location of the MODULE.bazel file")
@@ -82,6 +82,10 @@ func (sl *swiftLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 	// CheckFlags.
 	if sc.DependencyIndexPath == "" {
 		sc.DependencyIndexPath = filepath.Join(c.RepoRoot, sc.DependencyIndexRel)
+	}
+
+	if sc.BazelModulePath == "" {
+		sc.BazelModulePath = filepath.Join(c.RepoRoot, sc.BazelModuleRel)
 	}
 
 	// Attempt to load the module index. This is created by update-repos if the client is using

--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -38,6 +38,11 @@ func (*swiftLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) 
 			"swift_update_packages_to_latest",
 			false,
 			"Determines whether to update the Swift packages to their latest eligible version.")
+		fs.BoolVar(
+			&sc.PrintBzlmodStanzas,
+			"print_bzlmod_stanzas",
+			false,
+			"Determines whether to print the bzlmod stanzas to add to a MODULE.bazel file.")
 	}
 
 	// Store the config for later steps

--- a/gazelle/internal/swift/BUILD.bazel
+++ b/gazelle/internal/swift/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "bazel_repo.go",
         "bazel_repo_name.go",
         "builtin_modules.go",
+        "bzlmod.go",
         "code_dir.go",
         "dependency_index.go",
         "doc.go",
@@ -57,6 +58,7 @@ go_test(
     srcs = [
         "bazel_label_test.go",
         "bazel_repo_name_test.go",
+        "bzlmod_test.go",
         "code_dir_test.go",
         "dependency_index_test.go",
         "file_info_test.go",

--- a/gazelle/internal/swift/bzlmod.go
+++ b/gazelle/internal/swift/bzlmod.go
@@ -31,8 +31,7 @@ func BzlmodStanzas(di *DependencyIndex) (string, error) {
 	return b.String(), nil
 }
 
-const bzlmodPrefix = `
-swift_deps = use_extension(
+const bzlmodPrefix = `swift_deps = use_extension(
     "@cgrindel_swift_bazel//:extensions.bzl",
     "swift_deps",
 )

--- a/gazelle/internal/swift/bzlmod.go
+++ b/gazelle/internal/swift/bzlmod.go
@@ -1,0 +1,48 @@
+package swift
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+func BzlmodStanzas(di *DependencyIndex) (string, error) {
+	directDepPkgs := di.DirectDepPackages()
+	directDepNames := make([]string, len(directDepPkgs))
+	for idx, pkg := range directDepPkgs {
+		directDepNames[idx] = pkg.Name
+	}
+	slices.Sort(directDepNames)
+
+	var b strings.Builder
+	if _, err := fmt.Fprint(&b, bzlmodPrefix); err != nil {
+		return "", err
+	}
+	for _, name := range directDepNames {
+		if _, err := fmt.Fprintf(&b, bzlmodNameTmpl, name); err != nil {
+			return "", err
+		}
+	}
+	if _, err := fmt.Fprint(&b, bzlmodSuffix); err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+const bzlmodPrefix = `
+swift_deps = use_extension(
+    "@cgrindel_swift_bazel//:extensions.bzl",
+    "swift_deps",
+)
+swift_deps.from_file(
+    deps_index = "//:swift_deps_index.json",
+)
+use_repo(
+    swift_deps,
+`
+
+const bzlmodNameTmpl = "    \"%s\",\n"
+
+const bzlmodSuffix = ")\n"

--- a/gazelle/internal/swift/bzlmod_test.go
+++ b/gazelle/internal/swift/bzlmod_test.go
@@ -32,8 +32,7 @@ func TestBzlmodStanzas(t *testing.T) {
 
 	actual, err := swift.BzlmodStanzas(di)
 	assert.NoError(t, err)
-	expected := `
-swift_deps = use_extension(
+	expected := `swift_deps = use_extension(
     "@cgrindel_swift_bazel//:extensions.bzl",
     "swift_deps",
 )

--- a/gazelle/internal/swift/bzlmod_test.go
+++ b/gazelle/internal/swift/bzlmod_test.go
@@ -1,0 +1,50 @@
+package swift_test
+
+import (
+	"testing"
+
+	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBzlmodStanzas(t *testing.T) {
+	awesomeRepoId := "awesome-repo"
+	awesomePkg := &swift.Package{
+		Name:     swift.RepoNameFromIdentity(awesomeRepoId),
+		Identity: awesomeRepoId,
+		Remote: &swift.RemotePackage{
+			Commit: "12345",
+			Remote: "https://github.com/example/awesome-repo",
+		},
+	}
+	anotherRepoID := "another-repo"
+	anotherPkg := &swift.Package{
+		Name:     swift.RepoNameFromIdentity(anotherRepoID),
+		Identity: anotherRepoID,
+		Local: &swift.LocalPackage{
+			Path: "path/to/another",
+		},
+	}
+
+	di := swift.NewDependencyIndex()
+	di.AddPackage(awesomePkg, anotherPkg)
+	di.AddDirectDependency(awesomeRepoId, anotherRepoID)
+
+	actual, err := swift.BzlmodStanzas(di)
+	assert.NoError(t, err)
+	expected := `
+swift_deps = use_extension(
+    "@cgrindel_swift_bazel//:extensions.bzl",
+    "swift_deps",
+)
+swift_deps.from_file(
+    deps_index = "//:swift_deps_index.json",
+)
+use_repo(
+    swift_deps,
+    "swiftpkg_another_repo",
+    "swiftpkg_awesome_repo",
+)
+`
+	assert.Equal(t, expected, actual)
+}

--- a/gazelle/internal/swift/dependency_index.go
+++ b/gazelle/internal/swift/dependency_index.go
@@ -126,6 +126,22 @@ func (di *DependencyIndex) AddPackage(packages ...*Package) {
 	di.packageIndex.Add(packages...)
 }
 
+func (di *DependencyIndex) GetPackage(identity string) *Package {
+	if pkg, ok := di.packageIndex[identity]; ok {
+		return pkg
+	}
+	return nil
+}
+
+func (di *DependencyIndex) DirectDepPackages() []*Package {
+	directDepIdentities := di.DirectDepIdentities()
+	results := make([]*Package, len(directDepIdentities))
+	for idx, identity := range directDepIdentities {
+		results[idx] = di.GetPackage(identity)
+	}
+	return results
+}
+
 // Resolve
 
 type ModuleResolutionResult struct {

--- a/gazelle/internal/swift/dependency_index_test.go
+++ b/gazelle/internal/swift/dependency_index_test.go
@@ -135,6 +135,7 @@ func TestDependencyIndex(t *testing.T) {
 	// Puprosefully put bazPrd before fooPrd. Need to ensure that overalp affinity is accounted for.
 	di.AddProduct(bazPrd, barPrd, otherPrd, fooPrd, anotherFooPrd)
 	di.AddPackage(awesomePkg, anotherPkg)
+	di.AddDirectDependency(directIdentities...)
 
 	t.Run("resolve module names to products", func(t *testing.T) {
 		tests := []struct {
@@ -249,5 +250,32 @@ func TestDependencyIndex(t *testing.T) {
 		newMI, err := swift.NewDependencyIndexFromJSON(data)
 		assert.NoError(t, err)
 		assert.Equal(t, di, newMI)
+	})
+	t.Run("get package", func(t *testing.T) {
+		tests := []struct {
+			msg      string
+			identity string
+			exp      *swift.Package
+		}{
+			{
+				msg:      "exists",
+				identity: awesomeRepoId,
+				exp:      awesomePkg,
+			},
+			{
+				msg:      "does not exist",
+				identity: "does-not-exist",
+				exp:      nil,
+			},
+		}
+		for _, tt := range tests {
+			actual := di.GetPackage(tt.identity)
+			assert.Equal(t, tt.exp, actual, tt.msg)
+		}
+	})
+	t.Run("get direct packages", func(t *testing.T) {
+		actual := di.DirectDepPackages()
+		expected := []*swift.Package{awesomePkg}
+		assert.Equal(t, expected, actual)
 	})
 }

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -28,6 +28,7 @@ type SwiftConfig struct {
 	ResolutionLogPath   string
 	ResolutionLogFile   *os.File
 	ResolutionLogger    reslog.ResolutionLogger
+	PrintBzlmodStanzas  bool
 }
 
 func NewSwiftConfig() *SwiftConfig {

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -29,6 +29,8 @@ type SwiftConfig struct {
 	ResolutionLogFile   *os.File
 	ResolutionLogger    reslog.ResolutionLogger
 	PrintBzlmodStanzas  bool
+	UpdateBzlmodStanzas bool
+	BazelModulePath     string
 }
 
 func NewSwiftConfig() *SwiftConfig {

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -30,7 +30,9 @@ type SwiftConfig struct {
 	ResolutionLogger    reslog.ResolutionLogger
 	PrintBzlmodStanzas  bool
 	UpdateBzlmodStanzas bool
-	BazelModulePath     string
+	BazelModuleRel      string
+	// BazelModulePath is the full path to the MODULE.bazel
+	BazelModulePath string
 }
 
 func NewSwiftConfig() *SwiftConfig {

--- a/gazelle/internal/updmarker/BUILD.bazel
+++ b/gazelle/internal/updmarker/BUILD.bazel
@@ -18,3 +18,9 @@ go_test(
 )
 
 bzlformat_pkg(name = "bzlformat")
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["*"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/gazelle/internal/updmarker/BUILD.bazel
+++ b/gazelle/internal/updmarker/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "updmarker",
+    srcs = ["updater.go"],
+    importpath = "github.com/cgrindel/swift_bazel/gazelle/internal/updmarker",
+    visibility = ["//gazelle:__subpackages__"],
+)
+
+go_test(
+    name = "updmarker_test",
+    srcs = ["updater_test.go"],
+    deps = [
+        ":updmarker",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)
+
+bzlformat_pkg(name = "bzlformat")

--- a/gazelle/internal/updmarker/updater.go
+++ b/gazelle/internal/updmarker/updater.go
@@ -1,0 +1,88 @@
+package updmarker
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Updater struct {
+	StartMarker string
+	EndMarker   string
+}
+
+func NewUpdater(startMarker, endMarker string) *Updater {
+	return &Updater{
+		StartMarker: startMarker,
+		EndMarker: endMarker,
+	}
+}
+
+func (u *Updater) UpdateString(original, snippet string) (string, error) {
+	var newContent string
+	origLen := len(original)
+	startIdx := strings.Index(original, u.StartMarker)
+	endIdx := strings.Index(original, u.EndMarker)
+	if startIdx < 0 && endIdx < 0 {
+		startIdx = origLen
+	} else if startIdx >= 0 && endIdx >= 0 {
+		endIdx += len(u.EndMarker)
+	} else if startIdx > endIdx {
+		return "", fmt.Errorf("the start and end markers appear to be out of order")
+	} else if startIdx < 0 {
+		return "", fmt.Errorf("found the end marker, but did not find the start marker")
+	} else if endIdx < 0 {
+		return "", fmt.Errorf("found the start marker, but did not find the end marker")
+	}
+	appendSnippet := func(runes []rune) []rune {
+		runes = append(runes, []rune(u.StartMarker)...)
+		runes = append(runes, []rune(snippet)...)
+		runes = append(runes, []rune(u.EndMarker)...)
+		return runes
+	}
+	newRunes := make([]rune, 0, origLen + len(snippet))
+	for byteIdx, r := range original {
+		if byteIdx < startIdx || (endIdx >=0 && byteIdx >= endIdx) {
+			newRunes = append(newRunes, r)
+		} else if byteIdx == startIdx {
+			newRunes = appendSnippet(newRunes)
+		} 
+	}
+	if startIdx == origLen {
+		newRunes = appendSnippet(newRunes)
+	}
+	newContent = string(newRunes)
+	return newContent, nil
+}
+
+// func (u *Updater) UpdateString(original, snippet string) (string, error) {
+// 	var newContent string
+// 	startIdx := strings.Index(original, u.StartMarker)
+// 	endIdx := strings.Index(original, u.EndMarker)
+// 	if startIdx < 0 && endIdx < 0 {
+// 		// Append to end of file
+// 		newContent = fmt.Sprintf(
+// 			"%s%s%s%s",
+// 			original,
+// 			u.StartMarker,
+// 			snippet,
+// 			u.EndMarker,
+// 		)
+// 	} else if startIdx >= 0 && endIdx >= 0 {
+// 		endIdx += len(u.EndMarker)
+// 		// Replace the existing markers
+// 		runes := []rune(original)
+// 		newRunes := runes[0:startIdx]
+// 		newRunes = append(newRunes, []rune(u.StartMarker)...)
+// 		newRunes = append(newRunes, []rune(snippet)...)
+// 		newRunes = append(newRunes, []rune(u.EndMarker)...)
+// 		newRunes = append(newRunes, []rune(runes[endIdx:len(original)])...)
+// 		newContent = string(newRunes)
+// 	} else if startIdx > endIdx {
+// 		return "", fmt.Errorf("the start and end markers appear to be out of order")
+// 	} else if startIdx < 0 {
+// 		return "", fmt.Errorf("found the end marker, but did not find the start marker")
+// 	} else if endIdx < 0 {
+// 		return "", fmt.Errorf("found the start marker, but did not find the end marker")
+// 	}
+// 	return newContent, nil
+// }

--- a/gazelle/internal/updmarker/updater.go
+++ b/gazelle/internal/updmarker/updater.go
@@ -53,36 +53,3 @@ func (u *Updater) UpdateString(original, snippet string) (string, error) {
 	newContent = string(newRunes)
 	return newContent, nil
 }
-
-// func (u *Updater) UpdateString(original, snippet string) (string, error) {
-// 	var newContent string
-// 	startIdx := strings.Index(original, u.StartMarker)
-// 	endIdx := strings.Index(original, u.EndMarker)
-// 	if startIdx < 0 && endIdx < 0 {
-// 		// Append to end of file
-// 		newContent = fmt.Sprintf(
-// 			"%s%s%s%s",
-// 			original,
-// 			u.StartMarker,
-// 			snippet,
-// 			u.EndMarker,
-// 		)
-// 	} else if startIdx >= 0 && endIdx >= 0 {
-// 		endIdx += len(u.EndMarker)
-// 		// Replace the existing markers
-// 		runes := []rune(original)
-// 		newRunes := runes[0:startIdx]
-// 		newRunes = append(newRunes, []rune(u.StartMarker)...)
-// 		newRunes = append(newRunes, []rune(snippet)...)
-// 		newRunes = append(newRunes, []rune(u.EndMarker)...)
-// 		newRunes = append(newRunes, []rune(runes[endIdx:len(original)])...)
-// 		newContent = string(newRunes)
-// 	} else if startIdx > endIdx {
-// 		return "", fmt.Errorf("the start and end markers appear to be out of order")
-// 	} else if startIdx < 0 {
-// 		return "", fmt.Errorf("found the end marker, but did not find the start marker")
-// 	} else if endIdx < 0 {
-// 		return "", fmt.Errorf("found the start marker, but did not find the end marker")
-// 	}
-// 	return newContent, nil
-// }

--- a/gazelle/internal/updmarker/updater_test.go
+++ b/gazelle/internal/updmarker/updater_test.go
@@ -1,0 +1,100 @@
+package updmarker_test
+
+import (
+	"testing"
+
+	"github.com/cgrindel/swift_bazel/gazelle/internal/updmarker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdater(t *testing.T) {
+	startMarker := "# foo_bar START\n"
+	endMarker := "# foo_bar END\n"
+	updater := updmarker.NewUpdater(startMarker, endMarker)
+
+	t.Run("update string", func(t *testing.T) {
+		snippet := `Snippet First line
+🙂
+Snippet Second line
+`
+		tests := []struct {
+			msg string
+			in  string
+			exp string
+		}{
+			{
+				msg: "no markers in the input",
+				in: `
+Content First Line
+Content Second Line
+`,
+				exp: `
+Content First Line
+Content Second Line
+# foo_bar START
+Snippet First line
+🙂
+Snippet Second line
+# foo_bar END
+`,
+			},
+			{
+				msg: "markers in the middle of the input",
+				in: `
+Content First Line
+# foo_bar START
+# foo_bar END
+Content Second Line
+`,
+				exp: `
+Content First Line
+# foo_bar START
+Snippet First line
+🙂
+Snippet Second line
+# foo_bar END
+Content Second Line
+`,
+			},
+			{
+				msg: "markers at beginning of the input",
+				in: `# foo_bar START
+# foo_bar END
+Content First Line
+Content Second Line
+`,
+				exp: `# foo_bar START
+Snippet First line
+🙂
+Snippet Second line
+# foo_bar END
+Content First Line
+Content Second Line
+`,
+			},
+			{
+				msg: "markers at end of the input",
+				in: `
+Content First Line
+Content Second Line
+# foo_bar START
+# foo_bar END
+`,
+				exp: `
+Content First Line
+Content Second Line
+# foo_bar START
+Snippet First line
+🙂
+Snippet Second line
+# foo_bar END
+`,
+			},
+		}
+		for _, tt := range tests {
+			actual, err := updater.UpdateString(tt.in, snippet)
+			assert.NoError(t, err, tt.msg)
+			assert.Equal(t, tt.exp, actual, tt.msg)
+		}
+	})
+}

--- a/gazelle/update_repos.go
+++ b/gazelle/update_repos.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/language"
 	"github.com/bazelbuild/bazel-gazelle/rule"
@@ -11,6 +12,7 @@ import (
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swift"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftcfg"
 	"github.com/cgrindel/swift_bazel/gazelle/internal/swiftpkg"
+	"golang.org/x/exp/slices"
 )
 
 // language.RepoImporter Implementation
@@ -124,6 +126,12 @@ func importReposFromPackageManifest(args language.ImportReposArgs) language.Impo
 		di.AddPackage(pkg)
 	}
 
+	// Output a use_repo stanza for bzlmod.
+	if err := writeBzlmodStanzas(di); err != nil {
+		result.Error = err
+		return result
+	}
+
 	// Write the module index to a JSON file
 	if err := sc.WriteDependencyIndex(); err != nil {
 		result.Error = err
@@ -176,3 +184,47 @@ func readResolvedPkgPins(resolvedPkgPath string) (map[string]*spreso.Pin, error)
 	}
 	return pinsByIdentity, nil
 }
+
+func writeBzlmodStanzas(di *swift.DependencyIndex) error {
+	directDepPkgs := di.DirectDepPackages()
+	directDepNames := make([]string, len(directDepPkgs))
+	for idx, pkg := range directDepPkgs {
+		directDepNames[idx] = pkg.Name
+	}
+	slices.Sort(directDepNames)
+
+	var b strings.Builder
+	if _, err := fmt.Fprint(&b, bzlmodPrefix); err != nil {
+		return err
+	}
+	for _, name := range directDepNames {
+		if _, err := fmt.Fprintf(&b, bzlmodNameTmpl, name); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprint(&b, bzlmodSuffix); err != nil {
+		return err
+	}
+
+	fmt.Print(b.String())
+
+	return nil
+}
+
+const bzlmodPrefix = `
+swift_deps = use_extension(
+    "@cgrindel_swift_bazel//:extensions.bzl",
+    "swift_deps",
+)
+swift_deps.from_file(
+    deps_index = "//:swift_deps_index.json",
+)
+use_repo(
+    swift_deps,
+`
+
+const bzlmodNameTmpl = "    \"%s\", \n"
+
+const bzlmodSuffix = `
+)
+`

--- a/gazelle/update_repos.go
+++ b/gazelle/update_repos.go
@@ -125,7 +125,7 @@ func importReposFromPackageManifest(args language.ImportReposArgs) language.Impo
 	}
 
 	// Output a use_repo stanza for bzlmod.
-	if err := writeBzlmodStanzas(di); err != nil {
+	if err := writeBzlmodStanzas(di, sc); err != nil {
 		result.Error = err
 		return result
 	}
@@ -183,13 +183,19 @@ func readResolvedPkgPins(resolvedPkgPath string) (map[string]*spreso.Pin, error)
 	return pinsByIdentity, nil
 }
 
-func writeBzlmodStanzas(di *swift.DependencyIndex) error {
+func writeBzlmodStanzas(di *swift.DependencyIndex, sc *swiftcfg.SwiftConfig) error {
+	if !sc.PrintBzlmodStanzas {
+		return nil
+	}
 	bzlmodStanzas, err := swift.BzlmodStanzas(di)
 	if err != nil {
 		return err
 	}
-	if _, err = fmt.Print(bzlmodStanzas); err != nil {
+	if _, err = fmt.Printf("%s\n%s", bzlmodInstructions, bzlmodStanzas); err != nil {
 		return err
 	}
 	return nil
 }
+
+const bzlmodInstructions = `If you have enabled bzlmod, add the following to your 'MODULE.bazel' file to 
+load your Swift dependencies:`

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -7,7 +7,6 @@ build --incompatible_strict_action_env=true
 # Test output information
 test --test_output=errors --test_summary=detailed
 
-# GH276: Enable bzlmod
-# # Enable bzlmod
-# common --enable_bzlmod
-# build --@cgrindel_bazel_starlib//bzlmod:enabled
+# Enable bzlmod
+common --enable_bzlmod
+build --@cgrindel_bazel_starlib//bzlmod:enabled

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -7,6 +7,7 @@ build --incompatible_strict_action_env=true
 # Test output information
 test --test_output=errors --test_summary=detailed
 
-# Enable bzlmod
-common --enable_bzlmod
-build --@cgrindel_bazel_starlib//bzlmod:enabled
+# GH276: Enable bzlmod
+# # Enable bzlmod
+# common --enable_bzlmod
+# build --@cgrindel_bazel_starlib//bzlmod:enabled

--- a/swiftpkg/internal/swift_update_packages.bzl
+++ b/swiftpkg/internal/swift_update_packages.bzl
@@ -35,6 +35,9 @@ def swift_update_packages(
         print_bzlmod_stanzas: Optional. Determines whether the Gazelle
             extension prints out bzlmod Starlark code that can be pasted into
             your `MODULE.bazel`.
+        update_bzlmod_stanzas: Optional. Determines whether the Gazelle
+            extension adds/updates the bzlmod Starlark code to MODULE.bazel.
+        bazel_module: Optional. The relative path to the `MODULE.bazel` file.
         **kwargs: Attributes that are passed along to the gazelle declarations.
     """
     _SWIFT_UPDATE_REPOS_ARGS = [

--- a/swiftpkg/internal/swift_update_packages.bzl
+++ b/swiftpkg/internal/swift_update_packages.bzl
@@ -10,6 +10,8 @@ def swift_update_packages(
         swift_deps_fn = "swift_dependencies",
         swift_deps_index = "swift_deps_index.json",
         print_bzlmod_stanzas = False,
+        update_bzlmod_stanzas = False,
+        bazel_module = "MODULE.bazel",
         **kwargs):
     """Defines gazelle update-repos targets that are used to resolve and update \
     Swift package dependencies.
@@ -43,9 +45,12 @@ def swift_update_packages(
         ),
         "-prune",
         "-swift_dependency_index={}".format(swift_deps_index),
+        "-bazel_module={}".format(bazel_module),
     ]
     if print_bzlmod_stanzas:
         _SWIFT_UPDATE_REPOS_ARGS.append("-print_bzlmod_stanzas")
+    if update_bzlmod_stanzas:
+        _SWIFT_UPDATE_REPOS_ARGS.append("-update_bzlmod_stanzas")
 
     _gazelle(
         name = name,

--- a/swiftpkg/internal/swift_update_packages.bzl
+++ b/swiftpkg/internal/swift_update_packages.bzl
@@ -9,6 +9,7 @@ def swift_update_packages(
         swift_deps = "swift_deps.bzl",
         swift_deps_fn = "swift_dependencies",
         swift_deps_index = "swift_deps_index.json",
+        print_bzlmod_stanzas = False,
         **kwargs):
     """Defines gazelle update-repos targets that are used to resolve and update \
     Swift package dependencies.
@@ -29,6 +30,9 @@ def swift_update_packages(
         swift_deps_index: Optional. The relative path to the Swift
             dependencies index JSON file. This path is relative to the
             repository root, not the location of this declaration.
+        print_bzlmod_stanzas: Optional. Determines whether the Gazelle
+            extension prints out bzlmod Starlark code that can be pasted into
+            your `MODULE.bazel`.
         **kwargs: Attributes that are passed along to the gazelle declarations.
     """
     _SWIFT_UPDATE_REPOS_ARGS = [
@@ -40,6 +44,8 @@ def swift_update_packages(
         "-prune",
         "-swift_dependency_index={}".format(swift_deps_index),
     ]
+    if print_bzlmod_stanzas:
+        _SWIFT_UPDATE_REPOS_ARGS.append("-print_bzlmod_stanzas")
 
     _gazelle(
         name = name,


### PR DESCRIPTION
- Add `-print_bzlmod_stanzas` flag to `update-repos`. Enabling the option will print the relevant stanzas to stdout.
- Add `-update_bzlmod_stanzas` flag to `update-repos`. Enabling the option will add/update the stanzas to `MODULE.bazel`. NOTE: This mechanism is very rudimentary using comment markers to identify what to replace. A [design doc for a better solution](https://docs.google.com/document/d/1dj8SN5L6nwhNOufNqjBhYkk5f-BJI_FPYWKxlB3GAmA/edit?usp=sharing) has been submitted for review by @fmeum.

Related to #276